### PR TITLE
Sparsify more NLP models

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/NER1.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NER1.scala
@@ -212,9 +212,8 @@ class NER1 extends DocumentAnnotator {
     // Sparsify the evidence weights
     import scala.language.reflectiveCalls
     val sparseEvidenceWeights = new la.DenseLayeredTensor2(BilouConllNerDomain.size, FeaturesDomain.dimensionSize, new la.SparseIndexedTensor1(_))
-    sparseEvidenceWeights += model.evidence.weights.value.copy // Copy because += does not know how to handle AdaGradRDA tensor types
+    model.evidence.weights.value.foreachElement((i, v) => if (v != 0.0) sparseEvidenceWeights += (i, v))
     model.evidence.weights.set(sparseEvidenceWeights)
-    println("NER1.serialize evidence "+model.evidence.weights.value.getClass.getName)
     val dstream = new java.io.DataOutputStream(stream)
     BinarySerializer.serialize(FeaturesDomain.dimensionDomain, dstream)
     BinarySerializer.serialize(model, dstream)

--- a/src/main/scala/cc/factorie/app/nlp/ner/NER2.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NER2.scala
@@ -293,6 +293,9 @@ class NER2 extends DocumentAnnotator {
   }
   def serialize(stream: java.io.OutputStream): Unit = {
     import CubbieConversions._
+    val sparseEvidenceWeights = new la.DenseLayeredTensor2(BilouOntonotesNerDomain.size, FeaturesDomain.dimensionDomain.size, new la.SparseIndexedTensor1(_))
+    model3.evidence.weights.value.foreachElement((i, v) => if (v != 0.0) sparseEvidenceWeights += (i, v))
+    model3.evidence.weights.set(sparseEvidenceWeights)
     val dstream = new java.io.DataOutputStream(stream)
     BinarySerializer.serialize(FeaturesDomain.dimensionDomain, dstream)
     BinarySerializer.serialize(model3, dstream)
@@ -302,6 +305,7 @@ class NER2 extends DocumentAnnotator {
     import CubbieConversions._
     val dstream = new java.io.DataInputStream(stream)
     BinarySerializer.deserialize(FeaturesDomain.dimensionDomain, dstream)
+    model3.evidence.weights.set(new la.DenseLayeredTensor2(BilouOntonotesNerDomain.size, FeaturesDomain.dimensionDomain.size, new la.SparseIndexedTensor1(_)))
     BinarySerializer.deserialize(model3, dstream)
     //model3.parameters.densify()
     println("NER2 model parameters oneNorm "+model3.parameters.oneNorm)

--- a/src/main/scala/cc/factorie/app/nlp/parse/DepParser1.scala
+++ b/src/main/scala/cc/factorie/app/nlp/parse/DepParser1.scala
@@ -184,7 +184,7 @@ class DepParser1(val useLabels: Boolean) extends DocumentAnnotator {
   def serialize(stream: java.io.OutputStream): Unit = {
     import CubbieConversions._
     val sparseEvidenceWeights = new la.DenseLayeredTensor2(ActionDomain.size, FeaturesDomain.dimensionSize, new la.SparseIndexedTensor1(_))
-    sparseEvidenceWeights += model.weights.value.copy // Copy because += does not know how to handle AdaGradRDA tensor types
+    model.weights.value.foreachElement((i, v) => if (v != 0.0) sparseEvidenceWeights += (i, v))
     model.weights.set(sparseEvidenceWeights)
     println("DepParser1.serialize evidence "+model.weights.value.getClass.getName)
     val dstream = new java.io.DataOutputStream(stream)
@@ -257,7 +257,7 @@ class DepParser1(val useLabels: Boolean) extends DocumentAnnotator {
   }
 
   case class TrainOptions(val l2: Double, val l1: Double, val lrate: Double, val optimizer: String)  
-  def train(trainSentences:Seq[Sentence], testSentences:Seq[Sentence], devSentences:Seq[Sentence], name: String, nThreads: Int, options: TrainOptions, numIteration: Int = 10): Unit = {
+  def train(trainSentences:Seq[Sentence], testSentences:Seq[Sentence], devSentences:Seq[Sentence], name: String, nThreads: Int, options: TrainOptions, numIteration: Int = 3): Unit = {
     featuresSkipNonCategories = false
     println("Generating trainActions...")
     val trainActions = new ArrayBuffer[Action]()

--- a/src/main/scala/cc/factorie/app/nlp/parse/DepParser2.scala
+++ b/src/main/scala/cc/factorie/app/nlp/parse/DepParser2.scala
@@ -53,12 +53,6 @@ class DepParser2 extends DocumentAnnotator {
     import scala.language.reflectiveCalls
     val sparseEvidenceWeights = new la.DenseLayeredTensor2(labelDomain.size, featuresDomain.dimensionDomain.size, new la.SparseIndexedTensor1(_))
     model.weights.value.foreachElement((i, v) => if (v != 0.0) sparseEvidenceWeights += (i, v))
-//    //sparseEvidenceWeights += model.weights.value.copy // Copy because += does not know how to handle AdaGradRDA tensor types
-//    println("DepParser2.serialize checking sparsification not different.")
-//    assert(!sparseEvidenceWeights.different(model.weights.value, 0.001))
-//    println("Checking dot matches")
-//    val u = new la.DenseTensor2(labelDomain.size, featuresDomain.dimensionDomain.size, 1.0)
-//    assert(maths.almostEquals(sparseEvidenceWeights.dot(u), model.weights.value.dot(u), 0.001))
     model.weights.set(sparseEvidenceWeights)
     val dstream = new java.io.DataOutputStream(stream)
     BinarySerializer.serialize(featuresDomain.dimensionDomain, dstream)

--- a/src/main/scala/cc/factorie/app/nlp/pos/POS1.scala
+++ b/src/main/scala/cc/factorie/app/nlp/pos/POS1.scala
@@ -232,6 +232,9 @@ class POS1 extends DocumentAnnotator {
   }
   def serialize(stream: java.io.OutputStream): Unit = {
     import CubbieConversions._
+    val sparseEvidenceWeights = new la.DenseLayeredTensor2(PTBPosDomain.size, FeatureDomain.dimensionSize, new la.SparseIndexedTensor1(_))
+    model.weights.value.foreachElement((i, v) => if (v != 0.0) sparseEvidenceWeights += (i, v))
+    model.weights.set(sparseEvidenceWeights)
     val dstream = new java.io.DataOutputStream(stream)
     BinarySerializer.serialize(FeatureDomain.dimensionDomain, dstream)
     BinarySerializer.serialize(model, dstream)
@@ -242,6 +245,7 @@ class POS1 extends DocumentAnnotator {
     import CubbieConversions._
     val dstream = new java.io.DataInputStream(stream)
     BinarySerializer.deserialize(FeatureDomain.dimensionDomain, dstream)
+    model.weights.set(new la.DenseLayeredTensor2(PTBPosDomain.size, FeatureDomain.dimensionDomain.size, new la.SparseIndexedTensor1(_)))
     BinarySerializer.deserialize(model, dstream)
     BinarySerializer.deserialize(WordData.ambiguityClasses, dstream)
     dstream.close()  // TODO Are we really supposed to close here, or is that the responsibility of the caller


### PR DESCRIPTION
POS1, NER1, NER2, DepParser1, DepParser2 all now sparsify their evidence weights.  Will break serialization on NER2 and POS1, but not the others.  They were already sparse.
