### PR TITLE
app.nlp.pos: Adding back POS2, a linear chain POS annotator

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/pos/POS2.scala
+++ b/src/main/scala/cc/factorie/app/nlp/pos/POS2.scala
@@ -128,7 +128,7 @@ object POS2Trainer extends HyperparameterMain {
     if (opts.saveModel.value) {
       pos.serialize(new FileOutputStream(new File(opts.modelFile.value)))
       val pos2 = new POS2
-      pos2.deserialize(new java.io.File(opts.modelFile.value))
+      pos2.deserialize(new FileInputStream(new java.io.File(opts.modelFile.value)))
     }
     HammingObjective.accuracy(testDocs.flatMap(d => d.sentences.flatMap(s => s.tokens.map(_.posLabel))))
   }


### PR DESCRIPTION
This just adds back the old code for POS with a linear chain as POS2. It is useful because it's often convenient to have a graphical model for POS tag around (David & I use it for our research, for example).

I think it can be merged straight away. Training it is identical to training POS1.
