### PR TITLE
MentionEntityType annotation in NerAndPronounMentionFinder

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/mention/NerAndPronounMentionFinder.scala
+++ b/src/main/scala/cc/factorie/app/nlp/mention/NerAndPronounMentionFinder.scala
@@ -57,10 +57,11 @@ object NerAndPronounMentionFinder extends DocumentAnnotator {
   def process(document: Document) = {
     val nerMentions = getNerSpans(document).map(labelSpan => {
       val label = labelSpan._1
+      val mappedLabel = if(label == "PER") "PERSON" else label    //this is important if you do conll NER, since MentionEntityType expects Ontonotes NER Labels
       val s = labelSpan._2
       val m = new Mention(s, s.length-1)
       m.attr += new MentionType(m, "NAM")
-      m.attr += new MentionEntityType(m,label)
+      m.attr += new MentionEntityType(m,mappedLabel)
       m
     })
     val pronounMentions = getPronounSpans(document).map(s => {


### PR DESCRIPTION
adding stuff in NerAndPronounMentionFinder to add MentionEntityTypes directly, since the Ner tagger already produced types. This also adds MentionEntityType as a postAttr for this annotator. Note that new asymmetry between this annotator and the parse based mention finder, which does not have such a postAttr. Note that NerAndPronounMentionFinder can have either Conll or Ontonotes Ner has a prereq, but MentionEntityType requires an Ontonotes Ner tag. I convert Conll "PER" to Ontonotes "PERSON." Otherwise, nothing has to be translated (although there are certain tags in the MentionEntityTypeDomain that you'll never predict if you use Conll NER). 
