### PR TITLE
Improved ability for ParseBasedMentionFinding to add NerMentions

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/mention/NerAndPronounMentionFinder.scala
+++ b/src/main/scala/cc/factorie/app/nlp/mention/NerAndPronounMentionFinder.scala
@@ -61,8 +61,8 @@ object NerAndPronounMentionFinder extends DocumentAnnotator {
        "O"
   }
 
-  def process(document: Document) = {
-    val nerMentions = getNerSpans(document).map(labelSpan => {
+  def  getNerMentions(document: Document): Seq[Mention] = {
+    getNerSpans(document).map(labelSpan => {
       val label = labelSpan._1
       val mappedLabel = if(label == "PER") "PERSON" else label    //this is important if you do conll NER, since MentionEntityType expects Ontonotes NER Labels
       val s = labelSpan._2
@@ -71,6 +71,10 @@ object NerAndPronounMentionFinder extends DocumentAnnotator {
       m.attr += new MentionEntityType(m,mappedLabel)
       m
     })
+  }
+
+  def process(document: Document) = {
+    val nerMentions = getNerMentions(document)
     val pronounMentions = getPronounSpans(document).map(s => {
       val m = new Mention(s, 0)
       val label = getMentionEntityTypeLabelForPronoun(m)


### PR DESCRIPTION
refactored ner mention stuff so that parse-based-mention finder can grab these using the ner mention finding code. Now ParseBasedMentionFinding is a class that has a useNer flag. The object ParseBasedMentionFinding has useNer = false.

If you want to get mentions from both parsing and ner, use ParseAndNerBasedMentionFinding. Previously, it was possible to get NER mentions when using the parse-based-mention finder, but it was sketchy, since NER wasn't a prereq of the annotator, and NER could have been added to the document after parse based mention finding was called. Now it properly handles it as a prereq.

Note for future work: parse based mention finding still has a bunch of stuff hard coded in during tackbp to handle appositives. These should be removed in order to make the mentions returned by it more closely resemble the ontonotes annotation guidelines.
