### PR TITLE
add "initializeWeights" and "finalizeWeights" to GradientOptimizer

### DIFF
--- a/src/main/scala/cc/factorie/optimize/AdaGradRDA.scala
+++ b/src/main/scala/cc/factorie/optimize/AdaGradRDA.scala
@@ -36,6 +36,7 @@ class AdaGradRDA(val delta: Double = 0.1, val rate: Double = 0.1, val l1: Double
     weights.+=(gradient)
   }
   def initializeWeights(weights: WeightsSet): Unit = {
+    if (initialized) return
     for (key <- weights.keys) {
       key.value match {
         case t: AdaGradRDATensor => println("Warning: creating two AdaGradRDA optimizers on the same tensors. Reusing old one...")

--- a/src/main/scala/cc/factorie/optimize/ConjugateGradient.scala
+++ b/src/main/scala/cc/factorie/optimize/ConjugateGradient.scala
@@ -49,6 +49,9 @@ class ConjugateGradient(val initialStepSize: Double = 1.0) extends GradientOptim
     _isConverged = false
   }
 
+  def initializeWeights(weights: WeightsSet): Unit = { }
+  def finalizeWeights(weights: WeightsSet): Unit = { }
+
   def step(weights:WeightsSet, gradient:WeightsMap, value:Double): Unit = {
     if (_isConverged) return
     

--- a/src/main/scala/cc/factorie/optimize/GradientOptimizer.scala
+++ b/src/main/scala/cc/factorie/optimize/GradientOptimizer.scala
@@ -4,19 +4,41 @@ import cc.factorie._
 import cc.factorie.la._
 import cc.factorie.model.{WeightsMap, WeightsSet}
 
-/** Repeatedly call "step" until "isConverged" is true. */
+/** Base trait for optimizers that update weights according to a gradient. */
 trait GradientOptimizer {
-  //def step(gradient:Tensor, value:Double, margin:Double): Unit
   // TODO Why are we passing in weightsSet each time?  Couldn't this be dangerous?  -akm
-  def step(weights: WeightsSet, gradient: WeightsMap, value:Double): Unit
+  // I think passing it in here is probably a good compromise for optimizers that require no setup/teardown on weights or can do it automatically -luke
+  /**
+   * Updates the weights according to the gradient.
+   * @param weights The weights
+   * @param gradient The gradient
+   * @param value The value
+   */
+  def step(weights: WeightsSet, gradient: WeightsMap, value: Double): Unit
+  /**
+   * Whether the optimizer has converged yet.
+   */
   def isConverged: Boolean
+  /**
+   * Reset the optimizers internal state (such as Hessian approximation, etc.)
+   */
   def reset(): Unit
+  /**
+   * Some optimizers swap out weights with special purpose tensors for e.g. efficient scoring while learning.
+   * @param weights The weights
+   */
+  def initializeWeights(weights: WeightsSet): Unit
+  /**
+   * Once learning is done, the weights should be copied back into normal tensors.
+   * @param weights The weights
+   */
+  def finalizeWeights(weights: WeightsSet): Unit
 }
 
-/** Include L2 regularization (Gaussian with given scalar as the diagonal covariance) in the gradient and value. */
+/** Include L2 regularization (Gaussian with given scalar as the spherical covariance) in the gradient and value. */
 trait L2Regularization extends GradientOptimizer {
   var variance: Double = 10.0
-  abstract override def step(weights: WeightsSet, gradient: WeightsMap, value:Double) {
+  abstract override def step(weights: WeightsSet, gradient: WeightsMap, value: Double) {
     gradient += (weights, -1 / variance)
     super.step(weights, gradient, value - 0.5 / variance * (weights dot weights))
   }

--- a/src/main/scala/cc/factorie/optimize/GradientStep.scala
+++ b/src/main/scala/cc/factorie/optimize/GradientStep.scala
@@ -78,6 +78,9 @@ trait GradientStep extends GradientOptimizer {
    * To override if you want to reset internal state.
    */
   def reset(): Unit = { it = 0 }
+
+  def initializeWeights(weights: WeightsSet): Unit = { }
+  def finalizeWeights(weights: WeightsSet): Unit = { }
 }
 
 /**
@@ -90,10 +93,10 @@ trait ParameterAveraging extends GradientStep {
     super.doGradStep(weights, gradient, rate)
     wTmp += (gradient, rate*it)
   }
-
   def setWeightsToAverage(weights: WeightsSet): Unit = if (wTmp ne null) weights += (wTmp,-1.0/it)
   def unSetWeightsToAverage(weights: WeightsSet): Unit = if (wTmp ne null) weights += (wTmp,1.0/it)
   override def reset(): Unit = { super.reset(); wTmp = null }
+  override def finalizeWeights(weights: WeightsSet): Unit = setWeightsToAverage(weights)
 }
 
 /**

--- a/src/main/scala/cc/factorie/optimize/L2RegularizedConstantRate.scala
+++ b/src/main/scala/cc/factorie/optimize/L2RegularizedConstantRate.scala
@@ -19,7 +19,8 @@ class L2RegularizedConstantRate(l2: Double = 0.1, rate: Double = 0.1) extends Gr
     weights *= (1.0 - rate * l2)
   }
 
-  def initializeWeights(weights: WeightsSet) = {
+  def initializeWeights(weights: WeightsSet): Unit = {
+    if (initialized) return
     MutableScalableWeights.initializeWeights(weights)
     initialized = true
   }

--- a/src/main/scala/cc/factorie/optimize/LBFGS.scala
+++ b/src/main/scala/cc/factorie/optimize/LBFGS.scala
@@ -80,6 +80,9 @@ class LBFGS(var numIterations: Double = 1000,
 
   }
 
+  def initializeWeights(weights: WeightsSet): Unit = { }
+  def finalizeWeights(weights: WeightsSet): Unit = { }
+
   def step(weights:WeightsSet, gradient:WeightsMap, value:Double): Unit = {
     if (_isConverged) return
     //todo: is the right behavior to set _isConverged = true if exceeded numIters?

--- a/src/main/scala/cc/factorie/optimize/LineOptimizer.scala
+++ b/src/main/scala/cc/factorie/optimize/LineOptimizer.scala
@@ -60,7 +60,11 @@ class BackTrackLineOptimizer(val gradient:WeightsMap, val line:WeightsMap, val i
     tmplam = 0.0
     alam2 = 0.0
   }
-    def step(weights:WeightsSet, gradient:WeightsMap, value:Double): Unit = {
+
+  def initializeWeights(weights: WeightsSet): Unit = { }
+  def finalizeWeights(weights: WeightsSet): Unit = { }
+
+  def step(weights:WeightsSet, gradient:WeightsMap, value:Double): Unit = {
     logger.debug("BackTrackLineOptimizer step value="+value)
     // If first time in, do various initializations
     if (slope.isNaN) {
@@ -154,7 +158,7 @@ class BackTrackLineOptimizer(val gradient:WeightsMap, val line:WeightsMap, val i
 }
 
 
-/** Change the weightsSet in the direction of the gradient by using back-tracking line search to make sure we step up hill. */
+/** Change the weights in the direction of the gradient by using back-tracking line search to make sure we step up hill. */
 class LineSearchGradientAscent(var stepSize: Double = 1.0) extends GradientOptimizer with FastLogging {
   private var _isConverged = false
   def isConverged = _isConverged
@@ -168,6 +172,8 @@ class LineSearchGradientAscent(var stepSize: Double = 1.0) extends GradientOptim
     _isConverged = false
     oldValue = Double.NaN
   }
+  def initializeWeights(weights: WeightsSet): Unit = { }
+  def finalizeWeights(weights: WeightsSet): Unit = { }
   def step(weights: WeightsSet, gradient: WeightsMap, value: Double): Unit = {
     if (_isConverged) return
     // Check for convergence by value

--- a/src/main/scala/cc/factorie/optimize/Pegasos.scala
+++ b/src/main/scala/cc/factorie/optimize/Pegasos.scala
@@ -32,7 +32,7 @@ class Pegasos(baseRate: Double = 0.1, l2: Double = 0.01) extends GradientOptimiz
     step += 1
   }
 
-  def initializeWeights(weights: WeightsSet) = MutableScalableWeights.initializeWeights(weights)
+  def initializeWeights(weights: WeightsSet) = if (!initialized) MutableScalableWeights.initializeWeights(weights)
   def finalizeWeights(weights: WeightsSet) = MutableScalableWeights.finalizeWeights(weights)
 
   // can we get a good convergence criterion here? since it's not regular sgd, I feel like yes?

--- a/src/main/scala/cc/factorie/optimize/RDA.scala
+++ b/src/main/scala/cc/factorie/optimize/RDA.scala
@@ -19,6 +19,7 @@ class RDA(val rate: Double = 0.1, val l1: Double = 0.0, val l2: Double = 0.0) ex
     weights.+=(gradient)
   }
   def initializeWeights(weights: WeightsSet): Unit = {
+    if (initialized) return
     for (key <- weights.keys) key.value match {
       case t: Tensor1 => weights(key) = new RDATensor1(t.length, rate, l1, l2)
       case t: Tensor2 => weights(key) = new RDATensor2(t.dim1, t.dim2, rate, l1, l2)


### PR DESCRIPTION
Since many optimizers like averaging, RDA, l2 sgd do some special sleight of hand to swap the weights out for something more efficient, we should make this part of the regular API so we can handle it uniformly.
