### PR TITLE
Added a new function to TraversableExtras - split.

### DIFF
--- a/src/main/scala/cc/factorie/util/TraversableExtras.scala
+++ b/src/main/scala/cc/factorie/util/TraversableExtras.scala
@@ -19,19 +19,35 @@ import scala.util.Sorting
 import scala.reflect.ClassTag
 import scala.annotation.tailrec
 
+private class SplitIterator[A](t:Traversable[A], pred:(A => Boolean)) extends Iterator[Traversable[A]] {
+  var _first:Traversable[A] = null
+  var _rest:Traversable[A] = t
+
+  def hasNext: Boolean = _rest.nonEmpty && {
+    var r = _rest.span(pred)
+    _first = r._1; _rest = r._2
+    while(_first.isEmpty && _rest.nonEmpty) {
+      r = _rest.tail.span(pred)
+      _first = r._1; _rest = r._2
+    }
+    _first.nonEmpty
+  }
+
+  def next(): Traversable[A] = {
+    if(_first==null) {
+      hasNext
+    }
+    if(_first.isEmpty) {
+      throw new NoSuchElementException()
+    }
+    _first
+  }
+}
+
 /** New functionality on Traversable instances, available by implicit conversion in the cc.factorie package object in cc/factorie/package.scala. */
 final class TraversableExtras[A](val t: Traversable[A]) extends AnyVal {
 
-    def split(pred:(A => Boolean)):Iterable[Traversable[A]] = {
-      @tailrec def splitAcc(acc:List[Traversable[A]], elems:Traversable[A]):List[Traversable[A]] = {
-        val (first, rest) = elems span pred
-        if(elems.isEmpty) {acc}
-        else if(rest.isEmpty && first.nonEmpty) {first :: acc}
-        else if(first.isEmpty) {splitAcc(acc, rest.tail)}
-        else {splitAcc(first :: acc, rest.tail)}
-      }
-      splitAcc(Nil, t).reverse
-    }
+  def split(pred:(A => Boolean)):Iterator[Traversable[A]] = new SplitIterator[A](t, pred)
 
   def indexSafe(i: Int): Option[A] = if (i < t.size && i >= 0) Some(t.toSeq(i)) else None
 


### PR DESCRIPTION
Split takes a predicate and returns an Iterable of Traversables of all
the elements that satisfy the predicate, as split by all the elements
that don't satisfy the predicate. Concretely `(1 to 20).toSeq.split(_ % 2 ==
0)` will give a list seqs that contain 2, 4, 6, 8, etc.

Useful for partitioning OWPL-style files into seqs of sentences.
