### PR TITLE
doc annotator that can concatenate hyphenated tokens if they represent a single word

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/segment/DehyphenatingTokenizer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/segment/DehyphenatingTokenizer.scala
@@ -8,23 +8,29 @@ import scala.collection.mutable.ArrayBuffer
  * concatenates words split by hyphens in the original text based on user-provided dictionary
  * or other words in the same document. It works on the output of the tokenizer.
  * Caution: It modifies the output of the tokenizer by removing some tokens so run this before any other downstream tasks.
+ * @param tokenizer tokenizer to use to tokenize the doc. Default is DeterministicTokenizer
  * @param dictionary dictionary to lookup to check for merge eligibility
  * @param useTokens if true, other tokens in document are used to check for merge eligibility
  * @author harshal
  */
-class DeHyphenator(dictionary: Set[String] = Set.empty[String], useTokens: Boolean) extends DocumentAnnotator {
+class DehyphenatingTokenizer[T <: DocumentAnnotator](tokenizer: T = new DeterministicTokenizer(), dictionary: Set[String] = Set.empty[String], useTokens: Boolean) extends DocumentAnnotator {
+
+  def tokenize(document: Document) = tokenizer.process(document)
 
   def process(document: Document) = {
+    val tokenizedDoc = tokenize(document)
 
-    lazy val dictionaryFromDocWords = buildDictionaryFromDocWords(document.tokens)
+    lazy val dictionaryFromDocWords = buildDictionaryFromDocWords(tokenizedDoc.tokens)
 
     def eligibleForMerge(first: String, last:String) = dictionary((first+last).toLowerCase) || (useTokens && dictionaryFromDocWords((first+last).toLowerCase))
 
     var _skipCounter = 0
 
-    for(section <- document.sections){
+    for(section <- tokenizedDoc.sections){
       if(section.tokens.size>2){ //if the section has less than 3 tokens, nothing to do
+      var lastWindow: IndexedSeq[Token] = null
         for(tokens <- section.tokens.sliding(3).toList){
+          lastWindow = tokens
           if(_skipCounter==0 && tokens(1).string=="-" && tokens(2).hasFollowingWhitespace
             && eligibleForMerge(tokens(0).string, tokens(2).string)) {
             val first = tokens.head
@@ -46,19 +52,22 @@ class DeHyphenator(dictionary: Set[String] = Set.empty[String], useTokens: Boole
             }
           }
         }
+        //if the last window was merged then
+        if(_skipCounter>0){
+          section.remove(lastWindow(1).positionInSection)
+          section.remove(lastWindow(2).positionInSection)
+        }
       }
     }
-  document
-}
+    tokenizedDoc
+  }
 
-def buildDictionaryFromDocWords(tokens: Iterable[Token]) = tokens.filterNot(_.isPunctuation).map(_.string).toSet
+  def buildDictionaryFromDocWords(tokens: Iterable[Token]) = tokens.filterNot(_.isPunctuation).map(_.string).toSet
 
-// NOTE: this method may mutate and return the same document that was passed in
-def prereqAttrs = List(classOf[Token])
+  def prereqAttrs: Iterable[Class[_]] = Nil
+  def postAttrs:   Iterable[Class[_]] = List(classOf[Token])
 
-def postAttrs = List(classOf[Token])
-
-/** How the annotation of this DocumentAnnotator should be printed in one-word-per-line (OWPL) format.
+  /** How the annotation of this DocumentAnnotator should be printed in one-word-per-line (OWPL) format.
       If there is no per-token annotation, return null.  Used in Document.owplString. */
-def tokenAnnotationString(token: Token) = token.stringStart.toString+'\t'+token.stringEnd.toString
+  def tokenAnnotationString(token: Token) = token.stringStart.toString+'\t'+token.stringEnd.toString
 }


### PR DESCRIPTION
This doc annotator works on the output of the tokenizer and concatenates tokens if based on a user-provided dictionary or based on other tokens from the same document. 
It modifies the tokens so any other attrs on the tokens may be lost if tokens are concatenated.
