### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ To accomplish the same with sbt, type
 $ ./sbt compile
 ```
 
+You might need additional memory for sbt, if so type
+
+```
+export SBT_OPTS=-Xmx1g
+```
+
 To create a self-contained .jar, that contains FACTORIE plus all its dependencies, including the Scala runtime, type 
 
 ```


### PR DESCRIPTION
Add memory export for sbt.  It's likely that less memory would suffice, but I chose a reasonable amount that is sufficient (`Xmx1g`).
