### PR TITLE
adding ProducerConsumer Iterator

### DIFF
--- a/src/main/scala/cc/factorie/util/Threading.scala
+++ b/src/main/scala/cc/factorie/util/Threading.scala
@@ -5,6 +5,11 @@ import akka.actor.{Actor, Props, ActorSystem}
 import concurrent.duration.Duration
 import concurrent.{Future, Await}
 import akka.actor.Status.Success
+import java.util.concurrent.Executors
+import scala.concurrent._
+
+
+
 
 /**
  * User: apassos
@@ -49,6 +54,15 @@ object ProducerConsumerProcessing{
 
   object IteratorMutex
   def parForeach[In](xs: Iterator[In], numParallelJobs: Int = Runtime.getRuntime.availableProcessors(),perJobTimeout: Long = 10 ,overallTimeout: Long = 24)(body: In => Unit): Unit  = {
+
+    implicit val ec = new ExecutionContext {
+      val threadPool = Executors.newFixedThreadPool(numParallelJobs);
+      def execute(runnable: Runnable) {
+        threadPool.submit(runnable)
+      }
+      def reportFailure(t: Throwable) {}
+    }
+
     val system = ActorSystem("producer-consumer")
 
     val actors = (0 until numParallelJobs).map(i => system.actorOf(Props(new ParForeachActor(body)), "actor-"+i))


### PR DESCRIPTION
This adds a utility for calling foreach on an iterator without forcing the iterator. It uses a fixed size thread pool and offers utilities for per-task timeouts and a timeout for the overall job. I have used this a bunch this week and found it useful. Note that this is not the BufferedMappedIterator, which I have also written, but will make as a separate pull request after more testing. 
