### PR TITLE
fix the ambiguous import error in TestDecisionTree class.

### DIFF
--- a/src/test/scala/cc/factorie/optimize/TestDecisionTree.scala
+++ b/src/test/scala/cc/factorie/optimize/TestDecisionTree.scala
@@ -9,7 +9,6 @@ import cc.factorie.la.{SingletonTensor1, Tensor1, SparseIndexedTensor1, SparseBi
 import cc.factorie.util.BinarySerializer
 import cc.factorie.util.CubbieConversions._
 import cc.factorie.variable.{VectorDomain, DiscreteDomain}
-import cc.factorie.app.classify._
 import cc.factorie.app.classify.backend._
 
 class TestDecisionTree extends JUnitSuite {


### PR DESCRIPTION
Multiple classes are imported twice by including the line `import cc.factorie.app.classify._` as well as `import cc.factorie.app.classify.backend._`, causing compilation errors like the following:

```
reference to C45DecisionTreeTrainer is ambiguous;
it is imported twice in the same scope by
import cc.factorie.app.classify.backend._
and import cc.factorie.app.classify._
Error occurred in an application involving default arguments.
      new DecisionTreeMulticlassTrainer(new C45DecisionTreeTrainer))
```
