### PR TITLE
added classify cmd option

### DIFF
--- a/bin/fac
+++ b/bin/fac
@@ -51,6 +51,7 @@ CLASS=
 case $CMD in
 	nlp) CLASS=cc.factorie.app.nlp.NLP;;
 	lda) CLASS=cc.factorie.app.topics.lda.LDA;;
+	classify) CLASS=cc.factorie.app.classify.Classify;;
 	inter) CLASS=cc.factorie.util.Interpreter;;
 	run) CLASS=$1; shift;;
 	*) echo "Unrecognized command: $CMD"; help; exit 1;;


### PR DESCRIPTION
added classify cmd option; so that the `classify` examples from [tutorial](http://factorie.cs.umass.edu/tutorials/UsersGuide01Introduction.scala.html) could be executed, e.g.:

```
$ bin/fac classify --read-text-dirs sportsdir politicsdir --write-classifier mymodel.factorie
```
