### PR TITLE
adding WordEmbedding.scala

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/embeddings/WordEmbedding.scala
+++ b/src/main/scala/cc/factorie/app/nlp/embeddings/WordEmbedding.scala
@@ -1,0 +1,43 @@
+package cc.factorie.app.nlp.embeddings
+
+import cc.factorie.util.ClasspathURL
+import cc.factorie.la
+import java.util.zip.GZIPInputStream
+import cc.factorie.app.nlp.embeddings
+
+class WordEmbedding(val inputStreamFactory: () => java.io.InputStream, val dimensionSize: Int,numTake: Int = -1) extends scala.collection.mutable.LinkedHashMap[String,la.DenseTensor1] {
+  def sourceFactory(): io.Source = io.Source.fromInputStream(new GZIPInputStream(inputStreamFactory()),"iso-8859-1")
+
+  println("Reading Word Embeddings with dimension: %d".format(dimensionSize))
+
+  initialize()
+  def initialize() {
+    val source = sourceFactory()
+    var count = 0
+    val lines = if(numTake > 0) source.getLines().take(numTake) else source.getLines()
+    val firstLine = lines.next()
+    val firstFields = firstLine.split("\\s+")
+    val numLines = firstFields(0).toInt
+    val dimension = firstFields(1).toInt
+    assert(dimension == dimensionSize,"the specified dimension %d does not agree with the dimension %d given in the input file".format(dimension,dimensionSize))
+
+    for (line <- lines) {
+      val fields = line.split("\\s+")
+      val tensor = new la.DenseTensor1(fields.drop(1).map(_.toDouble))
+      assert(tensor.dim1 == dimensionSize,"the tensor has length " + tensor.dim1 + " , but it should have length + " + dimensionSize)
+      this(fields(0)) = tensor
+      count += 1
+      if (count % 100000 == 0) println("word vector count: %d".format(count))
+    }
+    source.close()
+  }
+
+}
+
+trait WordEmbeddingOptions extends cc.factorie.util.CmdOptions  {
+  val useEmbeddings = new CmdOption("use-embeddings",false,"BOOLEAN","Whether to use word embeddings")
+  val embeddingFile = new CmdOption("embedding-file", "", "STRING", "path to word2vec format file")
+  val embeddingDim = new CmdOption("embedding-dim", 100, "INT", "embedding dimension")
+  val embeddingScale = new CmdOption("embedding-scale", 10.0, "FLOAT", "The scale of the embeddings")
+  val numEmbeddingsToTake = new CmdOption("num-embeddings-to-take",-1,"INT","how many embeddings to take (assuming the file is sorted by word frequency. Default takes all of them")
+}


### PR DESCRIPTION
This pull request adds stuff for loading word embeddings in the format produced by Jeevan's new factorie word embedding training code, which is the same format as the Google word2vec files. This is designed to be used when plugging word embeddings into other NLP tasks in Factorie. 

There are two things I've added, a class called WordEmbedding, which essentially wraps a map from string to DenseTensor1, and WordEmbeddingOptions which provides a mixin for command line options for other nlp tasks. (note that this is different from command line arguments used when training word embeddings). 

**the Google embedding files and the ones Factorie produces are one-word-per-line, sorted by frequency. This is useful because you can take the first N lines from the file if you don't want to use all of the embeddings. The WordEmbedding constructor takes an optional final argument for the number of lines you want to take from the file**

*_Also note that the WordEmbedding class does not provide a default value for out-of-vocabulary words That needs to be handling outside, but checkout wordEmbedding.contains(str). *_

Here is an example of how to use the mix in the command line arguments:

class TransitionBasedParserWithEmbeddingsArgs extends TransitionBasedParserArgs with WordEmbeddingOptions

Here is an example of how to instantiate a WordEmbedding object
val useEmbeddings = opts.useEmbeddings.value
    if(useEmbeddings) println("using embeddings") else println("not using embeddings")
    val embedding = if(useEmbeddings)  new WordEmbedding(() => new FileInputStream(opts.embeddingFile.value),opts.embeddingDim.value,opts.numEmbeddingsToTake.value) else null
