### PR TITLE
Tagging Tensor with the Java serializable interface.

### DIFF
--- a/src/main/scala/cc/factorie/la/Tensor.scala
+++ b/src/main/scala/cc/factorie/la/Tensor.scala
@@ -23,7 +23,7 @@ import cc.factorie.util._
 // TODO Consider having all Tensor += methods return this.type.  Question: will this reduce efficiency? -akm
 
 /** An N-dimensional collection of Doubles. */
-trait Tensor extends MutableDoubleSeq {
+trait Tensor extends MutableDoubleSeq with Serializable {
   def numDimensions: Int
   def dimensions: Array[Int]
   // For handling sparsity


### PR DESCRIPTION
The FACTORIE Cubbie infrastructure directly stores Tensors as fields in the cubbie map, and unlike Cubbie, Tensor isn't Serializable. This makes it difficult to use FACTORIE with distributed computing platforms like Apache Spark, which require everything to be Serializable. Currently its possible to send most Cubbies over the wire (as they are extensions of Map), but it throws exceptions if they contain Tensors.

Tagging it with Serializable fixes this, and doesn't appear to have any side effects.
