### PR TITLE
Use a consistent scala version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ limitations under the License.
   <inceptionYear>2009</inceptionYear>
 
   <properties>
-    <scala.version>2.10.2</scala.version>
+    <scala.version>2.10.4</scala.version>
     <scalatest.version>1.9.1</scalatest.version>
     <junit.version>4.10</junit.version>
   </properties>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,7 +33,7 @@ object Build extends sbt.Build {
     settings(
       organization := "cc.factorie",
       version := "1.0-SNAPSHOT",
-      scalaVersion := "2.10.1",
+      scalaVersion := "2.10.4",
       scalacOptions := Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
       resolvers ++= Dependencies.resolutionRepos,
       libraryDependencies ++= Seq(
@@ -75,7 +75,7 @@ object Dependencies {
     val akka = "com.typesafe.akka" % "akka-actor_2.10" % "2.1.4"
     val jregex = "net.sourceforge.jregex" % "jregex" % "1.2_01"
     val colt = "org.jblas" % "jblas" % "1.2.3"
-    val compiler = "org.scala-lang" % "scala-compiler" % "2.10.1"
+    val compiler = "org.scala-lang" % "scala-compiler" % "2.10.4"
     val junit = "junit" % "junit" % "4.10"
   }
 


### PR DESCRIPTION
I found two different Scala versions between the pom.xml and build.sbt.
- 2.10.2
- 2.10.1

You should probably use the latest Scala 2.10 version, which is 2.10.4.  As this is binary compatible with the others, you should not have any trouble unless you are relying on a bug.

With the present set up, you will hit different bugs if you use Maven as your compilation system than if you use SBT as your compilation system.
