### PR TITLE
Fixed a missing type parameter in DiscreteSeqVar.value.

### DIFF
--- a/src/main/scala/cc/factorie/variable/DiscreteSeqVariable.scala
+++ b/src/main/scala/cc/factorie/variable/DiscreteSeqVariable.scala
@@ -60,7 +60,7 @@ trait MutableDiscreteSeqVar[A<:DiscreteValue] extends MutableVar with cc.factori
     def length = arr.length
     def apply(i:Int) = arr(i).asInstanceOf[A]
    //_toSeq.map(i => domain.elementDomain.getValue(i)) // TODO make this more efficient 
-  }.asInstanceOf
+  }.asInstanceOf[Value]
   def set(newValue:Value)(implicit d:DiffList): Unit = _set(Array.tabulate(newValue.length)(i => newValue(i).intValue))
   def trimCapacity(): Unit = _trimCapacity
   def clear(): Unit = _clear()


### PR DESCRIPTION
I get this stack trace when using a for loop over the words in an LDA document (for (word <- doc.ws)).

java.lang.ClassCastException: cc.factorie.variable.MutableDiscreteSeqVar$$anon$2 cannot be cast to scala.runtime.Nothing$
    at cc.factorie.variable.MutableDiscreteSeqVar$class.value(DiscreteSeqVariable.scala:57)
    at cc.factorie.variable.CategoricalSeqVariable.value(CategoricalSeqVariable.scala:52)
    at cc.factorie.variable.CategoricalSeqVariable.value(CategoricalSeqVariable.scala:52)
    at cc.factorie.variable.SeqSimilar$class.foreach(SeqVariable.scala:45)
    at cc.factorie.variable.CategoricalSeqVariable.foreach(CategoricalSeqVariable.scala:52)

Adding the type parameter to the asInstanceOf fixed it. I'm not sure what asInstanceOf is supposed to do without a type parameter.
