### PR TITLE
Bug Fix for TokenSpan's tokensString

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/TokenSpan.scala
+++ b/src/main/scala/cc/factorie/app/nlp/TokenSpan.scala
@@ -34,7 +34,7 @@ class TokenSpan(theSection:Section, initialStart:Int, initialLength:Int) extends
       If this is a multi-Token TokenSpan, this will include all original characters in the Document, including those skipped by tokenization. */
   def documentString: String = document.string.substring(tokens.head.stringStart, tokens.last.stringEnd) // TODO Handle Token.attr[TokenString] changes
   /** Return a String representation of this TokenSpan, concatenating each Token.string, separated by the given separator. */
-  def tokensString(separator:String): String = if (length == 1) chain(0).string else tokens.map(_.string).mkString(separator)
+  def tokensString(separator:String): String = if (length == 1) tokens(0).string else tokens.map(_.string).mkString(separator)
   /** Return a String representation of this TokenSpan, concatenating each Token.string, separated by a space.
       This nicely avoids newlines, HTML or other junk that might be in the phrase.documentString. */
   def string: String = tokensString(" ")


### PR DESCRIPTION
Calling tokensString on a token span of length 1 was returning the string of the first token in the section
