### PR TITLE
Bug fix for CollapseDigitsLemmatizer.

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/lemma/CollapseDigitsLemmatizer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/lemma/CollapseDigitsLemmatizer.scala
@@ -5,13 +5,13 @@ import cc.factorie.app.nlp._
 class CollapseDigitsLemmatizer extends DocumentAnnotator with Lemmatizer {
   def lemmatize(word:String): String = cc.factorie.app.strings.collapseDigits(word)
   def process(document:Document): Document = {
-    for (token <- document.tokens) token.attr += new SimplifyDigitsTokenLemma(token, lemmatize(token.string))
+    for (token <- document.tokens) token.attr += new CollapseDigitsTokenLemma(token, lemmatize(token.string))
     document
   }
   override def tokenAnnotationString(token:Token): String = { val l = token.attr[CollapseDigitsTokenLemma]; l.value }
   def prereqAttrs: Iterable[Class[_]] = List(classOf[Token])
   def postAttrs: Iterable[Class[_]] = List(classOf[CollapseDigitsTokenLemma])
 }
-object CollapseDigitsLemmatizer extends SimplifyDigitsLemmatizer
+object CollapseDigitsLemmatizer extends CollapseDigitsLemmatizer
 
 class CollapseDigitsTokenLemma(token:Token, s:String) extends TokenLemma(token, s)


### PR DESCRIPTION
It thought it was a SimplifyDigitsLemmatizer (object extended the
wrong class, and it's process method returned the wrong lemma).
