### PR TITLE
Fixed bug in Singlethreaded LDA

### DIFF
--- a/src/main/scala/cc/factorie/app/topics/lda/LDA.scala
+++ b/src/main/scala/cc/factorie/app/topics/lda/LDA.scala
@@ -116,7 +116,6 @@ class LDA(val wordSeqDomain: CategoricalSeqDomain[String], numTopics: Int = 10, 
     //sampler.debug = debug
     val startTime = System.currentTimeMillis
     for (i <- 1 to iterations) {
-
       val timeToEstAlpha = (i % fitAlphaInterval == 0) && i > burnIn
 
       val startIterationTime = System.currentTimeMillis
@@ -127,9 +126,7 @@ class LDA(val wordSeqDomain: CategoricalSeqDomain[String], numTopics: Int = 10, 
         println ("\n"+diagnosticName+"\nIteration "+i)
         sampler.export(phis)
         if (diagnosticShowPhrases) println(topicsWordsAndPhrasesSummary(10,10)) else println(topicsSummary(10))
-
       }
-
       /*if (i % fitAlphaInterval == 0) {
         sampler.exportThetas(documents)
         MaximizeDirichletByMomentMatching(alphas, model)

--- a/src/main/scala/cc/factorie/app/topics/lda/SparseLDAInferencer.scala
+++ b/src/main/scala/cc/factorie/app/topics/lda/SparseLDAInferencer.scala
@@ -290,7 +290,6 @@ class SparseLDAInferencer(
           // We've sampled from the topicTermMass
           phiCounts.incrementCountsAtPositions(wi, ti, -1, phiCountsWiTiPosition, newTi, 1, newPosition)
         } else {
-          //phiCounts(wi).incrementCountAtPosition(phiCountsWiTiPosition, -1) //ANTON: decrement the previous
           phiCounts.increment(wi, ti, -1)
           phiCounts.increment(wi, newTi, 1)
         }


### PR DESCRIPTION
Fixed SparseLDAInferencer to decrement document-topic counts which were not happening earlier. 
This would impact the running time of the single-threaded version making it slower. 
The multithreaded version performance is not affected.   
