### PR TITLE
Bug fix for lexicon loading on Windows.

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/lexicon/ResourceLexicons.scala
+++ b/src/main/scala/cc/factorie/app/nlp/lexicon/ResourceLexicons.scala
@@ -188,4 +188,4 @@ class ResourceLexicons(val sourceFactory: String=>io.Source, val tokenizer:Strin
 
 /** Static access through classpath or file location (specified as Java System Property)
     @author Andrew McCallum */
-object ClasspathResourceLexicons extends ResourceLexicons(string => { io.Source.fromURL(ClasspathURL.fromDirectory[Lexicon](string)) })
+object ClasspathResourceLexicons extends ResourceLexicons(string => { io.Source.fromURL(ClasspathURL.fromDirectory[Lexicon](string))(io.Codec.UTF8) })


### PR DESCRIPTION
The current codebase can't load the lexicons out of the jar on Windows in all cases, as sometimes the default Codec is set to something other than UTF8. This patches the ClasspathResourceLexicons to supply the UTF8 Codec.
