### PR TITLE
Germeval2014 NER competition category and tag definitions and loader

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/load/LoadGermeval2014.scala
+++ b/src/main/scala/cc/factorie/app/nlp/load/LoadGermeval2014.scala
@@ -1,0 +1,94 @@
+/* Copyright (C) 2008-2014 University of Massachusetts Amherst.
+   This file is part of "FACTORIE" (Factor graphs, Imperative, Extensible)
+   http://factorie.cs.umass.edu, http://github.com/factorie
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package cc.factorie.app.nlp.load
+
+import cc.factorie.app.nlp._
+import cc.factorie.app.nlp.ner._
+import cc.factorie.util.FastLogging
+
+import scala.io.Source
+import scala.collection.mutable.ArrayBuffer
+
+/* Loader for Germeval 2014 data
+   @author Peter Schueller
+  1   token ID
+  2   word form
+  3   gold named entity tag level 1
+  4   gold named entity tag level 2 (nested named entity)
+ */
+
+class LoadGermeval2014 extends Load with FastLogging {
+  // competition format = BIO
+  def fromSource(source:io.Source): Seq[Document] = fromSource(source,"BIO")
+  // alternate format = BILOU
+  def fromSource(source:io.Source, encoding:String): Seq[Document] = {
+    def newDocument(name:String): Document = {
+      var document = new Document("").setName(name)
+      document.annotators(classOf[Token]) = UnknownDocumentAnnotator.getClass
+      document.annotators(classOf[Sentence]) = UnknownDocumentAnnotator.getClass
+      encoding match {
+        case "BIO" => {
+          document.annotators(classOf[Lvl1BioGermevalNerTag]) = UnknownDocumentAnnotator.getClass
+          document.annotators(classOf[Lvl2BioGermevalNerTag]) = UnknownDocumentAnnotator.getClass }
+        case "BILOU" => {
+          document.annotators(classOf[Lvl1BilouGermevalNerTag]) = UnknownDocumentAnnotator.getClass
+          document.annotators(classOf[Lvl2BilouGermevalNerTag]) = UnknownDocumentAnnotator.getClass }
+        case _ => throw new Error("Germeval2014Load supports only BIO and BILOU encodings")
+      }
+      document
+    }
+
+    val documents = new ArrayBuffer[Document]
+    var document = newDocument("Germeval2014-"+documents.length)
+    documents += document
+    var sentence = new Sentence(document)
+    val rComment = """#.*""".r
+    val rEmpty = """\S*""".r
+    for (line <- source.getLines()) {
+      line match {
+        case rComment() => { } // ignore comments
+        case rEmpty() => {   // empty line starts new sentence
+          // be robust to double empty lines
+          if (sentence.tokens.size > 0) {
+            document.appendString("\n")
+            document.asSection.chainFreeze
+            document = newDocument("Germeval2014-"+documents.length)
+            documents += document
+            sentence = new Sentence(document)
+          } }
+        case _ => addToken(document, sentence, line, encoding)
+      }
+    }
+    logger.info("Loaded "+documents.length+" documents with "+documents.map(_.sentences.size).sum+" sentences with "+documents.map(_.tokens.size).sum+" tokens total")
+    documents
+  }
+
+  def addToken(document:Document, sentence:Sentence, line:String, encoding:String): Token = {
+    val fields = line.split("\t")
+    val word : String = fields(1)
+    val ner1gold : String = fields(2)
+    val ner2gold : String = fields(3)
+    if (sentence.length > 0) document.appendString(" ")
+    val token = new Token(sentence, word)
+    encoding match {
+      case "BIO" => {
+        token.attr += new LabeledLvl1BioGermevalNerTag(token, ner1gold)
+        token.attr += new LabeledLvl2BioGermevalNerTag(token, ner2gold) }
+      case "BILOU" => {
+        token.attr += new LabeledLvl1BilouGermevalNerTag(token, ner1gold)
+        token.attr += new LabeledLvl2BilouGermevalNerTag(token, ner2gold) }
+    }
+    token
+  }
+}
+

--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -310,3 +310,81 @@ class LabeledBilouOntonotesNerTag(token:Token, initialCategory:String) extends B
 
 // TODO Remove this. -akm
 class OntonotesEntityMentionSpan
+
+
+object GermevalNerDomain extends CategoricalDomain[String] {
+  this ++= Vector(
+   "O",
+   "OTH", "OTHpart", "OTHderiv",
+   "ORG", "ORGpart", "ORGderiv",
+   "LOC", "LOCpart", "LOCderiv",
+   "PER", "PERpart", "PERderiv"
+  )
+  freeze()
+}
+class GermevalNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = GermevalNerDomain }
+class LabeledGermevalNerTag(token:Token, initialCategory:String) extends GermevalNerTag(token, initialCategory) with CategoricalLabeling[String]
+
+class GermevalNerSpanLabel(span:TokenSpan, initialCategory:String) extends NerSpanLabel(span, initialCategory) { def domain = GermevalNerDomain }
+class GermevalNerSpan(section:Section, start:Int, length:Int, category:String) extends NerSpan(section, start, length) { val label = new GermevalNerSpanLabel(this, category) }
+class GermevalNerSpanBuffer extends TokenSpanBuffer[GermevalNerSpan]
+
+
+object BioGermevalNerDomain extends CategoricalDomain[String] {
+  this ++= Vector(
+      "O",
+      "B-OTH", "I-OTH", 
+      "B-OTHpart", "I-OTHpart", 
+      "B-OTHderiv", "I-OTHderiv", 
+      "B-ORG", "I-ORG", 
+      "B-ORGpart", "I-ORGpart", 
+      "B-ORGderiv", "I-ORGderiv", 
+      "B-LOC", "I-LOC", 
+      "B-LOCpart", "I-LOCpart", 
+      "B-LOCderiv", "I-LOCderiv", 
+      "B-PER", "I-PER",
+      "B-PERpart", "I-PERpart", 
+      "B-PERderiv", "I-PERderiv"
+  )
+  freeze()
+}
+
+// tags for both levels of NER annotation
+class Lvl1BioGermevalNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BioGermevalNerDomain }
+class LabeledLvl1BioGermevalNerTag(token:Token, initialCategory:String) extends Lvl1BioGermevalNerTag(token, initialCategory) with CategoricalLabeling[String]
+class Lvl2BioGermevalNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BioGermevalNerDomain }
+class LabeledLvl2BioGermevalNerTag(token:Token, initialCategory:String) extends Lvl2BioGermevalNerTag(token, initialCategory) with CategoricalLabeling[String]
+
+object BilouGermevalNerDomain extends CategoricalDomain[String] {
+  this ++= Vector(
+      "O",
+      "B-OTH", "I-OTH", "L-OTH", "U-OTH",
+      "B-OTHpart", "I-OTHpart", "L-OTHpart", "U-OTHpart",
+      "B-OTHderiv", "I-OTHderiv", "L-OTHderiv", "U-OTHderiv",
+      "B-ORG", "I-ORG", "L-ORG", "U-ORG",
+      "B-ORGpart", "I-ORGpart", "L-ORGpart", "U-ORGpart",
+      "B-ORGderiv", "I-ORGderiv", "L-ORGderiv", "U-ORGderiv",
+      "B-LOC", "I-LOC", "L-LOC", "U-LOC",
+      "B-LOCpart", "I-LOCpart", "L-LOCpart", "U-LOCpart",
+      "B-LOCderiv", "I-LOCderiv", "L-LOCderiv", "U-LOCderiv",
+      "B-PER", "I-PER", "L-PER", "U-PER",
+      "B-PERpart", "I-PERpart", "L-PERpart", "U-PERpart",
+      "B-PERderiv", "I-PERderiv", "L-PERderiv", "U-PERderiv"
+  )
+  freeze()
+  def lvl1SpanList(section:Section): GermevalNerSpanBuffer = {
+    val boundaries = bilouBoundaries(section.tokens.map(_.attr[Lvl1BilouGermevalNerTag].categoryValue))
+    new GermevalNerSpanBuffer ++= boundaries.map(b => new GermevalNerSpan(section, b._1, b._2, b._3))
+  } 
+  def lvl2SpanList(section:Section): GermevalNerSpanBuffer = {
+    val boundaries = bilouBoundaries(section.tokens.map(_.attr[Lvl2BilouGermevalNerTag].categoryValue))
+    new GermevalNerSpanBuffer ++= boundaries.map(b => new GermevalNerSpan(section, b._1, b._2, b._3))
+  } 
+}
+
+// tags for both levels of NER annotation
+class Lvl1BilouGermevalNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BilouGermevalNerDomain }
+class LabeledLvl1BilouGermevalNerTag(token:Token, initialCategory:String) extends Lvl1BilouGermevalNerTag(token, initialCategory) with CategoricalLabeling[String]
+class Lvl2BilouGermevalNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BilouGermevalNerDomain }
+class LabeledLvl2BilouGermevalNerTag(token:Token, initialCategory:String) extends Lvl2BilouGermevalNerTag(token, initialCategory) with CategoricalLabeling[String]
+


### PR DESCRIPTION
Dear all,

For the GermEval2014 NER competition (two-level nested NER) I added tag definitions to NerTag.scala and added a LoaderGermeval2014.scala program.

I represent the two levels as separate labelled variables and not as a cross-product (as in LoadConnl2000.scala) because 1) the domain has already 49 tags for one level  and 2) I will create factor graphs that treat the levels as distinct sets of variables.

Best,
Peter
