### PR TITLE
Replaces loading print statements with calls to logger

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -16,7 +16,7 @@ import model._
 import variable._
 import cc.factorie.app.nlp._
 import java.io.{BufferedInputStream, BufferedOutputStream, File}
-import cc.factorie.util.{BinarySerializer, CubbieConversions}
+import cc.factorie.util.{Logger, BinarySerializer, CubbieConversions}
 import cc.factorie.optimize.{Trainer, LikelihoodExample}
 import cc.factorie.infer.{InferByBPChain, DiscreteProposalMaximizer, MaximizeByBPChain}
 import cc.factorie.variable.{BinaryFeatureVectorVariable, CategoricalVectorDomain, DiscreteVar}
@@ -25,9 +25,11 @@ import cc.factorie.model.{DotTemplateWithStatistics2, TemplateModel, DotTemplate
 /** A simple named entity recognizer, trained on Ontonotes data.
     It does not have sufficient features to be state-of-the-art. */
 class BasicOntonotesNER extends DocumentAnnotator {
+  private val logger = Logger.getLogger(this.getClass.getName)
+
   def this(url:java.net.URL) = {
     this()
-    println("NER2 loading from "+url)
+    logger.debug("NER2 loading from "+url)
     deserialize(url.openConnection.getInputStream)
   }
 

--- a/src/main/scala/cc/factorie/app/nlp/parse/TransitionBasedParser.scala
+++ b/src/main/scala/cc/factorie/app/nlp/parse/TransitionBasedParser.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.{HashMap, ArrayBuffer}
 import scala.util.parsing.json.JSON
 import scala.annotation.tailrec
 import java.io._
-import cc.factorie.util.{BinarySerializer, FileUtils}
+import cc.factorie.util.{Logger, BinarySerializer, FileUtils}
 import scala._
 import cc.factorie.optimize._
 import scala.concurrent.Await
@@ -31,13 +31,15 @@ import scala.Some
 
 /** Default transition-based dependency parser. */
 class TransitionBasedParser extends DocumentAnnotator {
+  private val logger = Logger.getLogger(this.getClass.getName)
+
   def this(stream:InputStream) = { this(); deserialize(stream) }
   def this(file: File) = this(new FileInputStream(file))
   def this(url:java.net.URL) = {
     this()
     val stream = url.openConnection.getInputStream
     if (stream.available <= 0) throw new Error("Could not open "+url)
-    println("TransitionBasedParser loading from "+url)
+    logger.debug("TransitionBasedParser loading from "+url)
     deserialize(stream)
   }
 

--- a/src/main/scala/cc/factorie/app/nlp/pos/ForwardPosTagger.scala
+++ b/src/main/scala/cc/factorie/app/nlp/pos/ForwardPosTagger.scala
@@ -26,14 +26,19 @@ import cc.factorie.app.classify.backend.LinearMulticlassClassifier
     For the Viterbi-based part-of-speech tagger, see ChainPosTagger.  
     @author Andrew McCallum, */
 class ForwardPosTagger extends DocumentAnnotator {
+  private val logger = Logger.getLogger(this.getClass.getName)
+
   // Different ways to load saved parameters
   def this(stream:InputStream) = { this(); deserialize(stream) }
-  def this(file: File) = {this(new FileInputStream(file)); println("ForwardPosTagger loading from "+file.getAbsolutePath)}
+  def this(file: File) = {
+    this(new FileInputStream(file))
+    logger.debug("ForwardPosTagger loading from "+file.getAbsolutePath)
+  }
   def this(url:java.net.URL) = {
     this()
     val stream = url.openConnection.getInputStream
     if (stream.available <= 0) throw new Error("Could not open "+url)
-    println("ForwardPosTagger loading from "+url)
+    logger.debug("ForwardPosTagger loading from "+url)
     deserialize(stream)
   }
   


### PR DESCRIPTION
Several of the Factorie classes print to stdout when they load a model. This is very irritating in a larger system, when loading a model is a relatively unimportant action and clutters the logging output, so I replaced calls to `println` to calls to `logger.debug`.
