### PR TITLE
partial cleaning of module directed; new CollapsedGibbsSamplerHandler

### DIFF
--- a/src/main/scala/cc/factorie/app/topics/lda/LDA.scala
+++ b/src/main/scala/cc/factorie/app/topics/lda/LDA.scala
@@ -69,7 +69,7 @@ class LDA(val wordSeqDomain: CategoricalSeqDomain[String], numTopics: Int = 10, 
       require(doc.zs.domain.elementDomain.size == numTopics, "zs.domain.elementDomain.size=%d != numTopics=%d".format(doc.zs.domain.elementDomain.size, numTopics))
     }
     doc.zs.~(PlatedDiscrete(doc.theta))(m)
-    doc.ws.~(PlatedCategoricalMixture(phis, doc.zs))(m)
+    doc.ws.~(PlatedDiscreteMixture(phis, doc.zs))(m)
   }
 
   /** Add a document to the LDA model. */
@@ -153,10 +153,10 @@ class LDA(val wordSeqDomain: CategoricalSeqDomain[String], numTopics: Int = 10, 
 
     //Get global Nt and Nw,t for all the documents
     val phiCounts = new DiscreteMixtureCounts(wordDomain, ZDomain)
-    for (doc <- documents) phiCounts.incrementFactor(model.parentFactor(doc.ws).asInstanceOf[PlatedCategoricalMixture.Factor], 1)
+    for (doc <- documents) phiCounts.incrementFactor(model.parentFactor(doc.ws).asInstanceOf[PlatedDiscreteMixture.Factor], 1)
     val numTypes = wordDomain.length
 
-    val phiCountsArray = new Array[DiscreteMixtureCounts[String]](numThreads)
+    val phiCountsArray = new Array[DiscreteMixtureCounts](numThreads)
     val samplersArray = new Array[SparseLDAInferencer](numThreads)
 
     //Copy the counts to each thread
@@ -167,7 +167,7 @@ class LDA(val wordSeqDomain: CategoricalSeqDomain[String], numTopics: Int = 10, 
         val localPhiCounts = new DiscreteMixtureCounts(wordDomain, ZDomain)
         for (w <- 0 until numTypes) phiCounts(w).forCounts((t,c) => phiCountsArray(threadID).increment(w, t, c))
 
-        for (doc <- docSubsets(threadID)) localPhiCounts.incrementFactor(model.parentFactor(doc.ws).asInstanceOf[PlatedCategoricalMixture.Factor], 1)
+        for (doc <- docSubsets(threadID)) localPhiCounts.incrementFactor(model.parentFactor(doc.ws).asInstanceOf[PlatedDiscreteMixture.Factor], 1)
         samplersArray(threadID) = new SparseLDAInferencer(ZDomain, wordDomain, phiCountsArray(threadID),  alphas.value, beta1, model, random, localPhiCounts)
       })
 

--- a/src/main/scala/cc/factorie/app/topics/lda/SparseLDAInferencer.scala
+++ b/src/main/scala/cc/factorie/app/topics/lda/SparseLDAInferencer.scala
@@ -15,18 +15,18 @@ import cc.factorie._
 import cc.factorie.directed._
 import cc.factorie.util.DoubleSeq
 import scala.Array
-import cc.factorie.directed.{DirectedModel, PlatedCategoricalMixture, DiscreteMixtureCounts}
+import cc.factorie.directed.{DirectedModel, PlatedDiscreteMixture, DiscreteMixtureCounts}
 import cc.factorie.variable.{ProportionsVar, DiscreteSeqVariable, DiscreteDomain, CategoricalDomain}
 
 class SparseLDAInferencer(
     val zDomain:DiscreteDomain,
     val wordDomain:CategoricalDomain[String],
-    var phiCounts:DiscreteMixtureCounts[String],
+    var phiCounts:DiscreteMixtureCounts,
     initialAlphas:DoubleSeq,
     initialBeta1:Double,
     model:DirectedModel,
     random: scala.util.Random,
-    val localPhiCounts: DiscreteMixtureCounts[String] = null)
+    val localPhiCounts: DiscreteMixtureCounts = null)
 {
   var verbosity = 0
   var smoothingOnlyCount = 0; var topicBetaCount = 0; var topicTermCount = 0 // Just diagnostics
@@ -116,7 +116,7 @@ class SparseLDAInferencer(
     //smoothingMass = recalcSmoothingMass
     //assert(smoothingMass > 0.0)
     //println("process doc "+zs.words.asInstanceOf[Document].file)
-    val ws = model.childFactors(zs).head.asInstanceOf[PlatedCategoricalMixture.Factor]._1 //words
+    val ws = model.childFactors(zs).head.asInstanceOf[PlatedDiscreteMixture.Factor]._1 //words
     //assert(ws.length == zs.length)
     // r = sum_t ( \beta n_{t|d} ) ( n_t + |V| \beta )  [Mimno "Sparse LDA"]
     var topicBetaMass = 0.0
@@ -375,7 +375,7 @@ object SparseLDAInferencer {
     val phiCounts = new DiscreteMixtureCounts(wordDomain, zDomain)
 
     for (doc <- docs)
-      phiCounts.incrementFactor(model.parentFactor(doc.ws).asInstanceOf[PlatedCategoricalMixture.Factor], 1)
+      phiCounts.incrementFactor(model.parentFactor(doc.ws).asInstanceOf[PlatedDiscreteMixture.Factor], 1)
 
     new SparseLDAInferencer(zDomain, wordDomain, phiCounts, initialAlphas, initialBeta1, model, random)
   }

--- a/src/main/scala/cc/factorie/app/topics/lda/TopicsOverTime.scala
+++ b/src/main/scala/cc/factorie/app/topics/lda/TopicsOverTime.scala
@@ -32,7 +32,7 @@ object TopicsOverTime {
   object ZDomain extends DiscreteDomain(numTopics) { type Value = DiscreteValue }
   class Z(value: Int = 0) extends DiscreteVariable(value) { def domain = ZDomain }
   object WordDomain extends CategoricalDomain[String]
-  class Word(value: String) extends CategoricalVariable(value) { def domain = WordDomain; def z = model.parentFactor(this).asInstanceOf[CategoricalMixture[String]#Factor]._3 }
+  class Word(value: String) extends CategoricalVariable(value) { def domain = WordDomain; def z = model.parentFactor(this).asInstanceOf[DiscreteMixture#Factor]._3.asInstanceOf[Z] }
   class Document(val file: String) extends ArrayBuffer[Word] {
     var theta: ProportionsVariable = null
     var date: Long = -1  // datetime
@@ -57,7 +57,7 @@ object TopicsOverTime {
         for (word <- alphaSegmenter(file).map(_.toLowerCase).filter(!Stopwords.contains(_))) {
           val z = new Z :~ Discrete(doc.theta)
           val w = new Word(word)
-          CategoricalMixture.newFactor(w, phis, z)
+          DiscreteMixture.newFactor(w, phis, z)
           doc += w
           doc.stamps += new DoubleVariable ~ BetaMixture(balphas, bbetas, z)
         }

--- a/src/main/scala/cc/factorie/directed/Collapse.scala
+++ b/src/main/scala/cc/factorie/directed/Collapse.scala
@@ -84,9 +84,8 @@ object DenseCountsProportionsMixtureCollapser extends Collapser {
         for (f <- factors) f match {
           //case f:MixtureComponent.Factor => {}
           case f:Mixture.Factor => {}
-          case f:CategoricalMixture[_]#Factor => m(f._3.intValue).value.masses.+=(f._1.intValue, 1.0)
+          case f:DiscreteMixture#Factor => m(f._3.intValue).value.masses.+=(f._1.intValue, 1.0)
           case f:PlatedDiscreteMixture.Factor => (0 until f._1.length).foreach(i => m(f._3(i).intValue).value.masses.+=(f._1(i).intValue, 1.0))
-          case f:PlatedCategoricalMixture.Factor => (0 until f._1.length).foreach(i => m(f._3(i).intValue).value.masses.+=(f._1(i).intValue, 1.0))
           case f:Factor => { println("DenseCountsProportionsMixtureCollapser unexpected factor "+f); return false }
         }
         true

--- a/src/main/scala/cc/factorie/directed/DirectedFactor.scala
+++ b/src/main/scala/cc/factorie/directed/DirectedFactor.scala
@@ -15,7 +15,7 @@ package cc.factorie.directed
 
 import cc.factorie._
 import cc.factorie.model._
-import cc.factorie.variable.{MutableVar, Var}
+import cc.factorie.variable.{SeqVar, MutableVar, Var}
 
 trait DirectedFactor extends Factor {
   type ChildType <: Var
@@ -56,7 +56,19 @@ class GeneratedMutableVarWrapper[V<:MutableVar](val v:V) {
   }
 }
 
+//used for efficient sampling of sequence variables with parent factors
+trait SeqGeneratingFactor extends DirectedFactor {
+  type ChildType <: SeqVar[_]
+  def updateCollapsedParentsForIdx(weight: Double, idx: Int): Boolean = throw new Error(factorName + ": Collapsing parent at specified idx not implemented in " + this.getClass.getName)
+  def proportionalForChildIndex(idx:Int):Double
+}
 
+//used for efficient sampling of sequence variables with child factors
+trait SeqAsParentFactor extends DirectedFactor {
+  require(parents.count(_.isInstanceOf[SeqVar[_]]) == 1)
+  def updateCollapsedParentsForParentIdx(weight: Double, idx: Int): Boolean = throw new Error(factorName + ": Collapsing parent at specified idx not implemented in " + this.getClass.getName)
+  def proportionalForParentIndex(idx:Int):Double
+}
 
 trait RealGeneratingFactor extends DirectedFactor {
   def sampleDouble: Double

--- a/src/main/scala/cc/factorie/directed/DiscreteMixture.scala
+++ b/src/main/scala/cc/factorie/directed/DiscreteMixture.scala
@@ -18,30 +18,32 @@ import cc.factorie.variable._
 import cc.factorie.model.Model
 import cc.factorie.infer.{DiscreteSummary1, Summary, SimpleDiscreteMarginal1, Maximize}
 
-class CategoricalMixture[A] extends DirectedFamily3[CategoricalVariable[A],Mixture[ProportionsVariable],DiscreteVariable] {
-  case class Factor(override val _1:CategoricalVariable[A], override val _2:Mixture[ProportionsVariable], override val _3:DiscreteVariable) extends super.Factor(_1, _2, _3) with DiscreteGeneratingFactor with MixtureFactor {
+import scala.util.Random
+
+class DiscreteMixture extends DirectedFamily3[DiscreteVar,Mixture[ProportionsVariable],DiscreteVar] {
+  case class Factor(override val _1:DiscreteVar, override val _2:Mixture[ProportionsVariable], override val _3:DiscreteVar) extends super.Factor(_1, _2, _3) with DiscreteGeneratingFactor with MixtureFactor {
     def gate = _3
-    def pr(child:CategoricalValue[A], mixture:scala.collection.Seq[Proportions], z:DiscreteValue): Double = mixture(z.intValue).apply(child.intValue)
-    def sampledValue(mixture:_2.Value, z:_3.Value)(implicit random: scala.util.Random): _1.Value = _1.domain.apply(mixture(z.intValue).sampleIndex).asInstanceOf[_1.Value]
-    def prChoosing(child:CategoricalValue[A], mixture:scala.collection.Seq[Proportions], mixtureIndex:Int): Double = mixture(mixtureIndex).apply(child.intValue)
+    def pr(child:DiscreteVar#Value, mixture:scala.collection.Seq[Proportions], z:DiscreteVar#Value): Double = mixture(z.intValue).apply(child.intValue)
+    def sampledValue(mixture:P1#Value, z:P2#Value)(implicit random: scala.util.Random): _1.Value = _1.domain.apply(mixture(z.intValue).sampleIndex).asInstanceOf[_1.Value]
+    def prChoosing(child:DiscreteVar#Value, mixture:scala.collection.Seq[Proportions], mixtureIndex:Int): Double = mixture(mixtureIndex).apply(child.intValue)
     def prChoosing(mixtureIndex:Int): Double = _2(mixtureIndex).value.apply(_1.intValue)
-    def sampledValueChoosing(mixture:scala.collection.Seq[Proportions], mixtureIndex:Int)(implicit random: scala.util.Random): CategoricalValue[A] = _1.domain.apply(mixture(mixtureIndex).sampleIndex)
+    def sampledValueChoosing(mixture:scala.collection.Seq[Proportions], mixtureIndex:Int)(implicit random: scala.util.Random): DiscreteVar#Value = _1.domain.apply(mixture(mixtureIndex).sampleIndex).asInstanceOf[DiscreteVar#Value]
     def prValue(mixture:scala.collection.Seq[Proportions], mixtureIndex:Int, intValue:Int): Double = mixture.apply(mixtureIndex).apply(intValue)
     def prValue(intValue:Int) = prValue(_2.value.asInstanceOf[scala.collection.Seq[Proportions]], _3.intValue, intValue)
     override def updateCollapsedParents(weight:Double): Boolean = { _2(_3.intValue).value.masses.+=(_1.intValue, weight); true }
     // _2(_3.intValue) match case p:DenseCountsProportions => { p.increment(_1.intValue, weight)(null); true }
   }
-  def newFactor(a: CategoricalVariable[A], b: Mixture[ProportionsVariable], c:DiscreteVariable) = new Factor(a, b, c)
+  def newFactor(a: DiscreteVar, b: Mixture[ProportionsVariable], c:DiscreteVar) = new Factor(a, b, c)
 }
-object CategoricalMixture {
-  def newFactor[A](a:CategoricalVariable[A], b:Mixture[ProportionsVariable], c:DiscreteVariable)(implicit random: scala.util.Random): CategoricalMixture[A]#Factor = {
-    val dm = new CategoricalMixture[A]()
+object DiscreteMixture {
+  def newFactor(a:DiscreteVar, b:Mixture[ProportionsVariable], c:DiscreteVar)(implicit random: scala.util.Random): DiscreteMixture#Factor = {
+    val dm = new DiscreteMixture()
     dm.Factor(a, b, c)
   }
-  def apply[A](p1: Mixture[ProportionsVariable],p2:DiscreteVariable)(implicit random: scala.util.Random) = (c:CategoricalVariable[A]) => newFactor[A](c, p1, p2)
+  def apply(p1: Mixture[ProportionsVariable],p2:DiscreteVar)(implicit random: scala.util.Random) = (c:DiscreteVar) => newFactor(c, p1, p2)
 }
 
-class DiscreteMixtureCounts[A](val discreteDomain: CategoricalDomain[A], val mixtureDomain: DiscreteDomain) extends Seq[SortedSparseCounts] {
+class DiscreteMixtureCounts(val discreteDomain: DiscreteDomain, val mixtureDomain: DiscreteDomain) extends Seq[SortedSparseCounts] {
 
   // counts(wordIndex).countOfIndex(topicIndex)
   private val counts = Array.fill(discreteDomain.size)(new SortedSparseCounts(mixtureDomain.size))
@@ -61,8 +63,8 @@ class DiscreteMixtureCounts[A](val discreteDomain: CategoricalDomain[A], val mix
     assert(mixtureCounts(mixture) >= 0)
     counts(discrete).incrementCountAtIndex(mixture, incr)
   }
-  def incrementFactor(f:CategoricalMixture[A]#Factor, incr:Int): Unit = increment(f._1.intValue, f._3.intValue, incr)
-  def incrementFactor(f:PlatedCategoricalMixture.Factor, incr:Int): Unit = {
+  def incrementFactor(f:DiscreteMixture#Factor, incr:Int): Unit = increment(f._1.intValue, f._3.intValue, incr)
+  def incrementFactor(f:PlatedDiscreteMixture.Factor, incr:Int): Unit = {
     val discretes = f._1
     val gates = f._3
     assert (discretes.length == gates.length)
@@ -87,12 +89,12 @@ class DiscreteMixtureCounts[A](val discreteDomain: CategoricalDomain[A], val mix
 
 
 // TODO Currently only handles Gates of a CategoricalMixture; we should make it handle GaussianMixture also.
-object MaximizeGate extends Maximize[Iterable[DiscreteVariable],Model] {
+object MaximizeGate extends Maximize[Iterable[MutableDiscreteVar],Model] {
   // Underlying workhorse
-  def maxIndex[A](gate:DiscreteVariable, df:Discrete.Factor, dmf:CategoricalMixture[A]#Factor): Int = {
+  def maxIndex[A](gate:MutableDiscreteVar, df:Discrete.Factor, dmf:DiscreteMixture#Factor): Int = {
     var max = Double.NegativeInfinity
     var maxi = 0
-    val statistics: CategoricalMixture[A]#Factor#StatisticsType = dmf.currentStatistics //(dmf._1.value, dmf._2.value, dmf._3.value)
+    val statistics: DiscreteMixture#Factor#StatisticsType = dmf.currentStatistics //(dmf._1.value, dmf._2.value, dmf._3.value)
     var i = 0; val size = gate.domain.size
     while (i < size) {
       val pr = df._2.value(i) * dmf.prChoosing(i)
@@ -102,28 +104,28 @@ object MaximizeGate extends Maximize[Iterable[DiscreteVariable],Model] {
     maxi
   }
   /** Returns -1 on failure. */
-  def maxIndex[A](gate:DiscreteVariable, model:Model): Int = {
+  def maxIndex[A](gate:MutableDiscreteVar, model:Model): Int = {
     val factors = model.factors(gate).toSeq
     if (factors.size != 2) return -1
     (factors(0), factors(1)) match {
-      case (df:Discrete.Factor, dmf:CategoricalMixture[A @unchecked]#Factor) => maxIndex(gate, df, dmf)
-      case (dmf:CategoricalMixture[A @unchecked]#Factor, df:Discrete.Factor) => maxIndex(gate, df, dmf)
+      case (df:Discrete.Factor, dmf:DiscreteMixture#Factor) => maxIndex(gate, df, dmf)
+      case (dmf:DiscreteMixture#Factor, df:Discrete.Factor) => maxIndex(gate, df, dmf)
       case _ => -1
     }
   }
   // For typical direct callers
-  def apply[A](gate:DiscreteVariable, df:Discrete.Factor, dmf:CategoricalMixture[A]#Factor): Unit = gate.set(maxIndex(gate, df, dmf))(null)
-  def apply(gate:DiscreteVariable, model:Model): Unit = {
+  def apply[A](gate:MutableDiscreteVar, df:Discrete.Factor, dmf:DiscreteMixture#Factor): Unit = gate.set(maxIndex(gate, df, dmf))(null)
+  def apply(gate:MutableDiscreteVar, model:Model): Unit = {
     val maxi = maxIndex(gate, model)
     if (maxi >= 0) gate.set(maxi)(null) else throw new Error("MaximizeGate unable to handle model factors.")
   }
   // For generic inference engines
-  def infer[V<:DiscreteVariable](varying:V, model:Model): SimpleDiscreteMarginal1[V] = {
+  def infer[V<:MutableDiscreteVar](varying:V, model:Model): SimpleDiscreteMarginal1[V] = {
     new SimpleDiscreteMarginal1(varying, new SingletonProportions1(varying.domain.size, maxIndex(varying, model)))
   }
-  def infer(variables:Iterable[DiscreteVariable], model:Model, marginalizing:Summary): DiscreteSummary1[DiscreteVariable] = {
+  def infer(variables:Iterable[MutableDiscreteVar], model:Model, marginalizing:Summary): DiscreteSummary1[MutableDiscreteVar] = {
     if (marginalizing ne null) throw new Error("Multivariate case yet implemented.")
-    val result = new DiscreteSummary1[DiscreteVariable]
+    val result = new DiscreteSummary1[MutableDiscreteVar]
     for (v <- variables) result += infer(v, model)
     result
   }

--- a/src/main/scala/cc/factorie/directed/Mixture.scala
+++ b/src/main/scala/cc/factorie/directed/Mixture.scala
@@ -25,7 +25,7 @@ import cc.factorie.variable._
 // For factors between a Mixture and the child generated from that Mixture
 trait MixtureFactor extends DirectedFactor {
   //type ChildType <: MixtureGeneratedVar
-  def gate: DiscreteVariable
+  def gate: DiscreteVar
   //def prChoosing(s:StatisticsType, mixtureIndex:Int): Double
   //def prChoosing(mixtureIndex:Int): Double = prChoosing(statistics, mixtureIndex)
   //def logprChoosing(s:StatisticsType, mixtureIndex:Int): Double = math.log(prChoosing(s, mixtureIndex))

--- a/src/main/scala/cc/factorie/tutorial/EfficientLDA.scala
+++ b/src/main/scala/cc/factorie/tutorial/EfficientLDA.scala
@@ -58,7 +58,7 @@ object EfficientLDA {
         val theta = ProportionsVariable.sortedSparseCounts(numTopics) ~ Dirichlet(alphas)
         val tokens = alphaSegmenter(file).map(_.toLowerCase).filter(!stopwords.contains(_)).toSeq
         val zs = new Zs(tokens.length) :~ PlatedDiscrete(theta)
-        documents += new Document(file.toString, theta, zs, tokens) ~ PlatedCategoricalMixture(phis, zs)
+        documents += new Document(file.toString, theta, zs, tokens) ~ PlatedDiscreteMixture(phis, zs)
       }
     }
 

--- a/src/main/scala/cc/factorie/tutorial/SimpleLDA.scala
+++ b/src/main/scala/cc/factorie/tutorial/SimpleLDA.scala
@@ -34,7 +34,7 @@ object SimpleLDA {
   val WordDomain = WordSeqDomain.elementDomain
   class Words(strings:Seq[String]) extends CategoricalSeqVariable(strings) {
     def domain = WordSeqDomain
-    def zs = model.parentFactor(this).asInstanceOf[PlatedCategoricalMixture.Factor]._3
+    def zs = model.parentFactor(this).asInstanceOf[PlatedDiscreteMixture.Factor]._3.asInstanceOf[Zs]
   }
   class Document(val file:String, val theta:ProportionsVar, strings:Seq[String]) extends Words(strings)
   val beta = MassesVariable.growableUniform(WordDomain, 0.1)
@@ -50,7 +50,7 @@ object SimpleLDA {
         val theta = ProportionsVariable.dense(numTopics) ~ Dirichlet(alphas)
         val tokens = alphaSegmenter(file).map(_.toLowerCase).filter(!Stopwords.contains(_)).toSeq
         val zs = new Zs(tokens.length) :~ PlatedDiscrete(theta)
-        documents += new Document(file.toString, theta, tokens) ~ PlatedCategoricalMixture(phis, zs)
+        documents += new Document(file.toString, theta, tokens) ~ PlatedDiscreteMixture(phis, zs)
       }
     }
 
@@ -61,6 +61,14 @@ object SimpleLDA {
 
     for (i <- 1 to 20) {
       for (doc <- documents) sampler.process(doc.zs)
+      var t = 0
+      println()
+      phis.foreach(p => {
+        print(t)
+        p.value.masses.activeElements.toSeq.sortBy(-_._2).take(10).foreach(el => print("\t" +WordDomain(el._1).category))
+        println()
+        t+=1
+      })
    }
   }
 }

--- a/src/main/scala/cc/factorie/tutorial/TopicsOverTime.scala
+++ b/src/main/scala/cc/factorie/tutorial/TopicsOverTime.scala
@@ -79,7 +79,7 @@ object TopicsOverTime {
         val theta = ProportionsVariable.sortedSparseCounts(numTopics) ~ Dirichlet(alphas)
         val tokens = alphaSegmenter(file).map(_.toLowerCase).filter(!stopwords.contains(_)).toSeq
         val zs = new Zs(tokens.length) :~ PlatedDiscrete(theta)
-        val doc = new Document(file.toString, theta, zs, tokens) ~ PlatedCategoricalMixture(phis, zs)
+        val doc = new Document(file.toString, theta, zs, tokens) ~ PlatedDiscreteMixture(phis, zs)
         doc.time = file.lastModified
         documents += doc
       }

--- a/src/main/scala/cc/factorie/variable/ProportionsVariable.scala
+++ b/src/main/scala/cc/factorie/variable/ProportionsVariable.scala
@@ -501,7 +501,7 @@ object MaximizeProportions extends Maximize[Iterable[ProportionsVariable],Direct
       // A simple DiscreteVar child of the Proportions
       case d:Discrete.Factor => incrementForDiscreteVar(d._1, 1.0)
       // A DiscreteVar child of a Mixture[Proportions]
-      case dm:CategoricalMixture[A @unchecked]#Factor => {
+      case dm:DiscreteMixture#Factor => {
         val gate = dm._3
         val gateMarginal:DiscreteMarginal1[DiscreteVar] = if (summary eq null) null else summary.marginal(gate) 
         //val qFactors = if (qModel eq null) Nil else qModel.factors(Seq(gate))


### PR DESCRIPTION
- new handler for collapsed gibbs sampler (for discrete values), which substitutes earlier special handlers
- removal of Categorical Factors, because they can all be represented by Discrete Factors using DiscreteVar as child and/or parent type
- resolves issue #178
- Introduces new traits that help during sampling: SeqGeneratingFactor, SeqAsParentFactor
- candidate selection for special cases can be done with new Mixin traits: (Plated)SelectedCandidatesCollapsedGibbsSamplerHandler
- small tests were conducted by training a simple LDA model
