### PR TITLE
Deprecated baseCategoryValue and changed its implementation to defer to

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -12,9 +12,8 @@
    limitations under the License. */
 
 package cc.factorie.app.nlp.ner
-import cc.factorie._
+
 import cc.factorie.app.nlp._
-import cc.factorie.util.Cubbie
 import cc.factorie.variable._
 
 // A "Tag" is a categorical label associated with a token.
@@ -25,8 +24,9 @@ import cc.factorie.variable._
 abstract class NerTag(val token:Token, initialCategory:String) extends CategoricalVariable(initialCategory) {
   /** Return "PER" instead of "I-PER". */
   def shortCategoryValue: String = if (categoryValue.length > 1 && categoryValue(1) == '-') categoryValue.substring(2) else categoryValue
-  def baseCategoryValue: String = if (intValue == 0) "O" else categoryValue.drop(2)
-  // TODO Pick just one of the above.
+
+  @deprecated("use shortCategoryValue instead")
+  def baseCategoryValue: String = shortCategoryValue
 }
 
 /** A categorical variable holding the named entity type of a TokenSpan.

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -365,9 +365,9 @@ class BasicOntonotesNER extends DocumentAnnotator {
     // A label having the most frequent value of all labels associated with all Tokens having the same string as the given Token, or null if there is no Token with matching string
     def mostFrequentLabel(token:Token): BilouOntonotesNerTag = filterByToken(token) match {
       case Nil => null
-      case tokens: Seq[Token] => tokens.groupBy(_.attr[BilouOntonotesNerTag].baseCategoryValue).maxBy(_._2.size)._2.head.attr[BilouOntonotesNerTag]
+      case tokens: Seq[Token] => tokens.groupBy(_.attr[BilouOntonotesNerTag].shortCategoryValue).maxBy(_._2.size)._2.head.attr[BilouOntonotesNerTag]
     }
-    private def mostFrequentLabel(tokens:Seq[Token]): BilouOntonotesNerTag = tokens.groupBy(_.attr[BilouOntonotesNerTag].baseCategoryValue).maxBy(_._2.size)._2.head.attr[BilouOntonotesNerTag]
+    private def mostFrequentLabel(tokens:Seq[Token]): BilouOntonotesNerTag = tokens.groupBy(_.attr[BilouOntonotesNerTag].shortCategoryValue).maxBy(_._2.size)._2.head.attr[BilouOntonotesNerTag]
 
     // Add a Token to the Queue and also to the internal hash
     override def +=(token:Token): this.type = {
@@ -375,7 +375,7 @@ class BasicOntonotesNER extends DocumentAnnotator {
       if (java.lang.Character.isUpperCase(str(0)) && !lexicon.StopWords.containsWord(str.toLowerCase)) { // Only add capitalized, non-stopword Tokens
         super.+=(token)
         hash.getOrElseUpdate(token.string, new scala.collection.mutable.Queue[Token]) += token
-        if (debugPrintCount % 1000 == 0) println("HashedTokenQueue %20s %20s  %-20s  %s true=%-10s  pred=%-10s  freq=%-5s  %s".format(token.getPrev.map(_.string).getOrElse(null), token.string, token.getNext.map(_.string).getOrElse(null), if (token.attr[LabeledBilouOntonotesNerTag].valueIsTarget) " " else "*", token.attr[LabeledBilouOntonotesNerTag].target.categoryValue, token.attr[BilouOntonotesNerTag].categoryValue, mostFrequentLabel(hash(token.string)).baseCategoryValue, hash(token.string).map(_.attr[BilouOntonotesNerTag].categoryValue).mkString(" ")))
+        if (debugPrintCount % 1000 == 0) println("HashedTokenQueue %20s %20s  %-20s  %s true=%-10s  pred=%-10s  freq=%-5s  %s".format(token.getPrev.map(_.string).getOrElse(null), token.string, token.getNext.map(_.string).getOrElse(null), if (token.attr[LabeledBilouOntonotesNerTag].valueIsTarget) " " else "*", token.attr[LabeledBilouOntonotesNerTag].target.categoryValue, token.attr[BilouOntonotesNerTag].categoryValue, mostFrequentLabel(hash(token.string)).shortCategoryValue, hash(token.string).map(_.attr[BilouOntonotesNerTag].categoryValue).mkString(" ")))
         debugPrintCount += 1
         if (length > maxSize) dequeue()
       }


### PR DESCRIPTION
shortCategoryValue

The previous implementation of baseCategoryValue made the assumption
that 'O' was always the first element added to the domain, which is not
generally true. This bit us on TAC recently. Rather than remove the method completely and break
things downstream, I've deprecated it and changed the implementation to
match shortCategoryValue.
