### PR TITLE
Add max2 method to DoubleSeq

### DIFF
--- a/src/main/scala/cc/factorie/util/DoubleSeq.scala
+++ b/src/main/scala/cc/factorie/util/DoubleSeq.scala
@@ -165,8 +165,8 @@ trait DenseDoubleSeq extends DoubleSeq {
     (max1, max2)
   }
   def max2: (Double, Double) = {
-    val l = length; var i = 0
-    var max1 = Double.NegativeInfinity; var max2 = Double.NegativeInfinity
+    val l = length; var i = 1
+    var max1 = apply(0); var max2 = apply(1)
     while (i < l) {
       if (max1 < apply(i)) { max2 = max1; max1 = apply(i) }
       else if (max2 < apply(i)) max2 = apply(i)


### PR DESCRIPTION
Convenient method for getting the max two values of a DoubleSeq. This can be done with existing maxIndex2, but when called frequently this will be a little faster since the values already have to be looked up to get the indices of the max two values. Also the convenience is good for avoiding silly mistakes.
