### PR TITLE
Replace shortCategoryValue with baseCategoryValue, deprecate

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -12,6 +12,7 @@
    limitations under the License. */
 
 package cc.factorie.app.nlp.ner
+
 import cc.factorie.app.nlp._
 import cc.factorie.variable._
 
@@ -21,11 +22,12 @@ import cc.factorie.variable._
      More specific subclasses have a domain, such as BilouConllNerDomain.
      @author Andrew McCallum */
 abstract class NerTag(val token:Token, initialCategory:String) extends CategoricalVariable(initialCategory) {
-  /** Return "PER" instead of "I-PER". */
-  def shortCategoryValue: String = if (categoryValue.length > 1 && categoryValue(1) == '-') categoryValue.substring(2) else categoryValue
-  def baseCategoryValue: String = if (intValue == 0) "O" else categoryValue.drop(2)
-  // TODO Pick just one of the above.
-}
+   /** Return "PER" instead of "I-PER". */
+   def baseCategoryValue: String = if (categoryValue.length > 1 && categoryValue(1) == '-') categoryValue.substring(2) else categoryValue
+
+   @deprecated("Use baseCategoryValue instead. This will be removed in the next release.")
+   def shortCategoryValue: String = baseCategoryValue
+ }
 
 /** A categorical variable holding the named entity type of a TokenSpan.
     More specific subclasses have a domain, such as ConllNerDomain.

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -504,7 +504,7 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
     ChainNer2FeaturesDomain.freeze()
     //println(trainDocuments(3).tokens.map(token => token.nerTag.target.categoryValue + " "+token.string+" "+token.attr[ChainNer2Features].toString).mkString("\n"))
     //println("Example Test Token features")
-    //println(testDocuments(1).tokens.map(token => token.nerTag.shortCategoryValue+" "+token.string+" "+token.attr[ChainNer2Features].toString).mkString("\n"))
+    //println(testDocuments(1).tokens.map(token => token.nerTag.baseCategoryValue+" "+token.string+" "+token.attr[ChainNer2Features].toString).mkString("\n"))
     (trainLabels ++ testLabels).foreach(_.setRandomly)
     val vars2 = for(td <- trainDocuments; sentence <- td.sentences if sentence.length > 1) yield sentence.tokens.map(_.attr[L with LabeledMutableDiscreteVar])
 


### PR DESCRIPTION
See PR #197, this is a resolved version from my fork (based on Jack's changes):
- shortCategoryValue is deprecated
- baseCategoryValue implementation changed to the implementation that was shortCategoryValue (which is correct)
