### PR TITLE
fix issue #208: Method not defined on using LDA

### DIFF
--- a/src/main/scala/cc/factorie/app/topics/lda/SparseLDAInferencer.scala
+++ b/src/main/scala/cc/factorie/app/topics/lda/SparseLDAInferencer.scala
@@ -102,7 +102,7 @@ class SparseLDAInferencer(
   def exportThetas(docs:Iterable[Doc]): Unit = {
     for (doc <- docs) {
       val theta = doc.theta
-      theta.value.zero()
+      theta.value.masses.zero()
       for (dv <- doc.zs.discreteValues) theta.value.masses.+=(dv.intValue, 1.0)
     }
   }


### PR DESCRIPTION
fix bug in SparseLDAInferencer.exportThetas where theta.value.zero() was calling a commented out function.
