### PR TITLE
Change default value of skipNonCategories to domain.dimensionDomain.frozen

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/phrase/NounPhraseEntityType.scala
+++ b/src/main/scala/cc/factorie/app/nlp/phrase/NounPhraseEntityType.scala
@@ -59,7 +59,6 @@ class OntonotesPhraseEntityTypeLabeler extends DocumentAnnotator {
   object FeatureDomain extends CategoricalVectorDomain[String]
   class FeatureVariable extends BinaryFeatureVectorVariable[String] {
     def domain = FeatureDomain
-    override def skipNonCategories: Boolean = domain.dimensionDomain.frozen
   }
   lazy val model = new LinearMulticlassClassifier(OntonotesEntityTypeDomain.size, FeatureDomain.dimensionDomain.size)
   

--- a/src/main/scala/cc/factorie/tutorial/ChainNERDemo.scala
+++ b/src/main/scala/cc/factorie/tutorial/ChainNERDemo.scala
@@ -128,13 +128,13 @@ object ChainNERDemo {
         println("---MaxProduct---")
         // printTokenMarginals(sentence.asSeq, BP.inferChainMax(sentence.asSeq.map(_.label), model))
         println("---Gibbs Sampling---")
-        //        predictor.processAll(testLabels, 2)
+        predictor.processAll(testLabels, 2)
         sentence.asSeq.foreach(token => printLabel(token.label))
       }
     } else {
       // Use VariableSettingsSampler for prediction
       //predictor.temperature *= 0.1
-      //      predictor.processAll(testLabels, 2)
+      predictor.processAll(testLabels, 2)
     }
 
     println ("Final Test  accuracy = "+ objective.accuracy(testLabels))

--- a/src/main/scala/cc/factorie/tutorial/ChainNERDemo.scala
+++ b/src/main/scala/cc/factorie/tutorial/ChainNERDemo.scala
@@ -11,8 +11,6 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-
-
 package cc.factorie.tutorial
 import cc.factorie._
 import java.io.File
@@ -41,7 +39,7 @@ object ChainNERDemo {
     def prev = token.prev.label
   }
   class Sentence extends Chain[Sentence,Token]
-  
+
   // The model
   val model = new TemplateModel with Parameters {
     // Bias term on each individual label
@@ -64,7 +62,7 @@ object ChainNERDemo {
     this += bias
     this += transtion
   }
-  
+
   // The training objective
   val objective = new HammingTemplate[Label, Label#TargetType]
 
@@ -78,63 +76,74 @@ object ChainNERDemo {
 
     // Get the variables to be inferred
     val trainLabels = trainSentences.flatMap(_.links.map(_.label)).take(50000) //.take(30000)
-    val testLabels = testSentences.flatMap(_.links.map(_.label))//.take(2000)
-    val allTokens: Seq[Token] = (trainLabels ++ testLabels).map(_.token)
 
-    // Add features from next and previous tokens 
+    // Add features from next and previous tokens
     // println("Adding offset features...")
-    allTokens.foreach(t => {
+    trainLabels.map(_.token).foreach(t => {
       if (t.hasPrev) t ++= t.prev.activeCategories.filter(!_.contains('@')).map(_+"@-1")
       if (t.hasNext) t ++= t.next.activeCategories.filter(!_.contains('@')).map(_+"@+1")
     })
 
+    // Freeze domain now that we've added all feature values observed in training data
+    TokenDomain.freeze()
     println("Using "+TokenDomain.dimensionSize+" observable features.")
-    
+
     // Print some significant features
     //println("Most predictive features:")
     //val pllo = new cc.factorie.app.classify.PerLabelLogOdds(trainSentences.flatMap(_.map(_.label)), (label:Label) => label.token)
     //for (label <- LabelDomain.values) println(label.category+": "+pllo.top(label, 20))
-    
+
     // Sample and Learn!
     val startTime = System.currentTimeMillis
-    (trainLabels ++ testLabels).foreach(_.setRandomly)
+    trainLabels.foreach(_.setRandomly)
     val learner = new optimize.SampleRankTrainer(new GibbsSampler(model, objective) {temperature=0.1}, new cc.factorie.optimize.AdaGrad)
     val predictor = new IteratedConditionalModes(model, null)
     for (i <- 1 to 3) {
       // println("Iteration "+i)
       learner.processContexts(trainLabels)
-      predictor.processAll(testLabels); predictor.processAll(trainLabels)
+      //      predictor.processAll(testLabels);
+      predictor.processAll(trainLabels)
       trainLabels.take(20).foreach(printLabel _); println(); println()
       printDiagnostic(trainLabels.take(400))
       //trainLabels.take(20).foreach(label => println("%30s %s %s %f".format(label.token.word, label.targetCategory, label.categoryValue, objective.currentScore(label))))
       //println ("Tr50  accuracy = "+ objective.accuracy(trainLabels.take(20)))
-      //println ("Train accuracy = "+ objective.accuracy(trainLabels))
-      println ("Test  accuracy = "+ objective.accuracy(testLabels))
+      println ("Train accuracy = "+ objective.accuracy(trainLabels))
+      //      println ("Test  accuracy = "+ objective.accuracy(testLabels))
     }
     if (false) {
       // Use BP Viterbi for prediction
       for (sentence <- testSentences)
         BP.inferChainMax(sentence.asSeq.map(_.label), model).setToMaximize(null)
-        //BP.inferChainSum(sentence.asSeq.map(_.label), model).setToMaximize(null) // max-marginal inference
-      
+      //BP.inferChainSum(sentence.asSeq.map(_.label), model).setToMaximize(null) // max-marginal inference
+
       for (sentence <- trainSentences.take(10)) {
         println("---SumProduct---")
         printTokenMarginals(sentence.asSeq, BP.inferChainSum(sentence.asSeq.map(_.label), model))
         println("---MaxProduct---")
         // printTokenMarginals(sentence.asSeq, BP.inferChainMax(sentence.asSeq.map(_.label), model))
         println("---Gibbs Sampling---")
-        predictor.processAll(testLabels, 2)
+        //        predictor.processAll(testLabels, 2)
         sentence.asSeq.foreach(token => printLabel(token.label))
       }
     } else {
       // Use VariableSettingsSampler for prediction
       //predictor.temperature *= 0.1
-      predictor.processAll(testLabels, 2)
+      //      predictor.processAll(testLabels, 2)
     }
+
+    // Compute features on test data
+    val testLabels = testSentences.flatMap(_.links.map(_.label))//.take(2000)
+    testLabels.map(_.token).foreach(t => {
+      if (t.hasPrev) t ++= t.prev.activeCategories.filter(!_.contains('@')).map(_+"@-1")
+      if (t.hasNext) t ++= t.next.activeCategories.filter(!_.contains('@')).map(_+"@+1")
+    })
+    testLabels.foreach(_.setRandomly)
+    predictor.processAll(testLabels, 2)
+
     println ("Final Test  accuracy = "+ objective.accuracy(testLabels))
     //println("norm " + model.weights.twoNorm)
     println("Finished in " + ((System.currentTimeMillis - startTime) / 1000.0) + " seconds")
-    
+
     //for (sentence <- testSentences) BP.inferChainMax(sentence.asSeq.map(_.label), model); println ("MaxBP Test accuracy = "+ objective.accuracy(testLabels))
     //for (sentence <- testSentences) BP.inferChainSum(sentence.asSeq.map(_.label), model).setToMaximize(null); println ("SumBP Test accuracy = "+ objective.accuracy(testLabels))
     //predictor.processAll(testLabels, 2); println ("Gibbs Test accuracy = "+ objective.accuracy(testLabels))
@@ -162,21 +171,21 @@ object ChainNERDemo {
   val Numeric = "^[0-9]+$".r
   val Punctuation = "[-,\\.;:?!()]+".r
 
-  
+
   def printLabel(label:Label) : Unit = {
     println("%-16s TRUE=%-8s PRED=%-8s %s".format(label.token.word, label.target.categoryValue, label.value.category, label.token.toString))
   }
- 
+
   def printDiagnostic(labels:Seq[Label]) : Unit = {
     for (label <- labels; if label.intValue != label.domain.index("O")) {
-      if (!label.hasPrev || label.value != label.prev.value) 
+      if (!label.hasPrev || label.value != label.prev.value)
         print("%-7s %-7s ".format(if (label.value != label.target.value) label.target.value.category.drop(2) else " ", label.value.category.drop(2)))
       print(label.token.word+" ")
       if (!label.hasNext || label.value != label.next.value) println()
     }
     println()
   }
- 
+
   def load(filename:String) : Seq[Sentence] = {
     import scala.io.Source
     import scala.collection.mutable.ArrayBuffer
@@ -205,5 +214,3 @@ object ChainNERDemo {
   }
 
 }
-
-

--- a/src/main/scala/cc/factorie/variable/CategoricalSeqVariable.scala
+++ b/src/main/scala/cc/factorie/variable/CategoricalSeqVariable.scala
@@ -57,7 +57,7 @@ abstract class CategoricalSeqVariable[C] extends MutableDiscreteSeqVar[Categoric
     initialValue.foreach(c => this += d.value(c))
   }
   def domain: CategoricalSeqDomain[C]
-  def skipNonCategories = false
+  def skipNonCategories = domain.elementDomain.frozen
   def appendCategory(x:C): Unit = {
     val index = domain.elementDomain.index(x)
     if (index >= 0) _append(index)

--- a/src/main/scala/cc/factorie/variable/CategoricalVectorVariable.scala
+++ b/src/main/scala/cc/factorie/variable/CategoricalVectorVariable.scala
@@ -58,7 +58,7 @@ trait CategoricalVectorVar[C] extends VectorVar {
   def domain: CategoricalVectorDomain[C]
   /** If false, then when += is called with a value (or index) outside the Domain, an error is thrown.
       If true, then no error is thrown, and request to add the outside-Domain value is simply ignored. */
-  def skipNonCategories = false
+  def skipNonCategories = domain.dimensionDomain.frozen
   protected def doWithIndexSafely(elt:C, v:Double, update:Boolean): Unit = {
     val i = domain.dimensionDomain.index(elt)
     if (i == CategoricalDomain.NULL_INDEX) {


### PR DESCRIPTION
This is the most common desired behavior, so it should be the default. If the domain is never frozen then this behavior is the same as the old behavior. Also, the old default (false) tends to cause ArrayIndexOutOfBounds exceptions when trying to predict on real data (when, as is often the case, features get computed that are outside the domain).

This PR also includes some changes to ChainNERDemo that demonstrate this common use case of first computing features on training data, then freezing the feature domain before computing test feats.