### PR TITLE
Some fixes to ParseTree

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/parse/ParseTree.scala
+++ b/src/main/scala/cc/factorie/app/nlp/parse/ParseTree.scala
@@ -45,7 +45,7 @@ class ParseTree(val sentence:Sentence, theTargetParents:Array[Int], theTargetLab
   def this(sentence:Sentence) = this(sentence, Array.fill[Int](sentence.length)(ParseTree.noIndex), Array.fill(sentence.length)(ParseTreeLabelDomain.defaultIndex)) // Note: this puts in dummy target data which may be confusing
   def this(sentence:Sentence, theTargetParents:Seq[Int], theTargetLabels:Seq[String]) = this(sentence, theTargetParents.toArray, theTargetLabels.map(c => ParseTreeLabelDomain.index(c)).toArray)
   def check(parents:Array[Int]): Unit = {
-    val l = sentence.length; var i = 0; while (i < l) {
+    val l = sentence.length; var i = 0; while (i < parents.length) {
       println(s"${parents(i)} / $l")
       require(parents(i) < l)
       i += 1

--- a/src/main/scala/cc/factorie/app/nlp/parse/ParseTree.scala
+++ b/src/main/scala/cc/factorie/app/nlp/parse/ParseTree.scala
@@ -45,7 +45,8 @@ class ParseTree(val sentence:Sentence, theTargetParents:Array[Int], theTargetLab
   def this(sentence:Sentence) = this(sentence, Array.fill[Int](sentence.length)(ParseTree.noIndex), Array.fill(sentence.length)(ParseTreeLabelDomain.defaultIndex)) // Note: this puts in dummy target data which may be confusing
   def this(sentence:Sentence, theTargetParents:Seq[Int], theTargetLabels:Seq[String]) = this(sentence, theTargetParents.toArray, theTargetLabels.map(c => ParseTreeLabelDomain.index(c)).toArray)
   def check(parents:Array[Int]): Unit = {
-    val l = parents.length; var i = 0; while (i < l) {
+    val l = sentence.length; var i = 0; while (i < l) {
+      println(s"${parents(i)} / $l")
       require(parents(i) < l)
       i += 1
     }

--- a/src/main/scala/cc/factorie/app/nlp/parse/ParseTree.scala
+++ b/src/main/scala/cc/factorie/app/nlp/parse/ParseTree.scala
@@ -46,7 +46,6 @@ class ParseTree(val sentence:Sentence, theTargetParents:Array[Int], theTargetLab
   def this(sentence:Sentence, theTargetParents:Seq[Int], theTargetLabels:Seq[String]) = this(sentence, theTargetParents.toArray, theTargetLabels.map(c => ParseTreeLabelDomain.index(c)).toArray)
   def check(parents:Array[Int]): Unit = {
     val l = sentence.length; var i = 0; while (i < parents.length) {
-      println(s"${parents(i)} / $l")
       require(parents(i) < l)
       i += 1
     }


### PR DESCRIPTION
To allow for building a tree from a list of dependencies that doesn't necessarily cover every token in the sentence.