### PR TITLE
Least surprise: Changed the default sparsity in Factor3 to fully dense

### DIFF
--- a/src/main/scala/cc/factorie/model/Factor3.scala
+++ b/src/main/scala/cc/factorie/model/Factor3.scala
@@ -369,17 +369,29 @@ trait Family3[N1<:Var,N2<:Var,N3<:Var] extends FamilyWithNeighborDomains {
   }
   // For implementing sparsity in belief propagation
   def hasLimitedDiscreteValues123 = limitedDiscreteValues123 != null && limitedDiscreteValues123.activeDomainSize < limitedDiscreteValues123.length
-  protected def getLimitedDiscreteValues123(factor:Factor3[VectorVar,VectorVar,VectorVar]): SparseBinaryTensor3 = { if (limitedDiscreteValues123 eq null) limitedDiscreteValues123 = new SparseBinaryTensor3(factor._1.domain.dimensionSize, factor._2.domain.dimensionSize, factor._3.domain.dimensionSize); limitedDiscreteValues123 }
+  protected def getLimitedDiscreteValues123(factor:Factor3[VectorVar,VectorVar,VectorVar]): SparseBinaryTensor3 = {
+    if (limitedDiscreteValues123 eq null) {
+      limitedDiscreteValues123 = new SparseBinaryTensor3(factor._1.domain.dimensionSize, factor._2.domain.dimensionSize, factor._3.domain.dimensionSize)
+      for (i <- 0 to limitedDiscreteValues123.size) limitedDiscreteValues123.+=(i, 1.0)
+    }; limitedDiscreteValues123 }
   var limitedDiscreteValues123: SparseBinaryTensor3 = null
 
   def hasLimitedDiscreteValues12 = limitedDiscreteValues12 != null && limitedDiscreteValues12.activeDomainSize < limitedDiscreteValues12.length
-  protected def getLimitedDiscreteValues12(factor:Factor3[VectorVar,VectorVar,_]): SparseBinaryTensor2 = { if (limitedDiscreteValues12 eq null) limitedDiscreteValues12 = new SparseBinaryTensor2(factor._1.domain.dimensionSize, factor._2.domain.dimensionSize); limitedDiscreteValues12 }
+  protected def getLimitedDiscreteValues12(factor:Factor3[VectorVar,VectorVar,_]): SparseBinaryTensor2 = {
+    if (limitedDiscreteValues12 eq null) {
+      limitedDiscreteValues12 = new SparseBinaryTensor2(factor._1.domain.dimensionSize, factor._2.domain.dimensionSize)
+      for (i <- 0 to limitedDiscreteValues12.size) limitedDiscreteValues12.+=(i, 1.0)
+    }; limitedDiscreteValues12 }
   var limitedDiscreteValues12: SparseBinaryTensor2 = null
-  
+
   def hasLimitedDiscreteValues1 = limitedDiscreteValues1 != null && limitedDiscreteValues1.activeDomainSize < limitedDiscreteValues1.length
-  protected def getLimitedDiscreteValues1(factor:Factor3[VectorVar,_,_]): SparseBinaryTensor1 = { if (limitedDiscreteValues1 eq null) limitedDiscreteValues1 = new SparseBinaryTensor1(factor._1.domain.dimensionSize); limitedDiscreteValues1 }
+  protected def getLimitedDiscreteValues1(factor:Factor3[VectorVar,_,_]): SparseBinaryTensor1 = {
+    if (limitedDiscreteValues1 eq null) {
+      limitedDiscreteValues1 = new SparseBinaryTensor1(factor._1.domain.dimensionSize)
+      for (i <- 0 to limitedDiscreteValues1.size) limitedDiscreteValues1.+=(i, 1.0)
+    }; limitedDiscreteValues1 }
   var limitedDiscreteValues1: SparseBinaryTensor1 = null
-  
+
 }
 
 trait TupleFamily3[N1<:Var,N2<:Var,N3<:Var] extends Family3[N1,N2,N3] {

--- a/src/test/scala/cc/factorie/infer/TestBP.scala
+++ b/src/test/scala/cc/factorie/infer/TestBP.scala
@@ -419,6 +419,59 @@ class TestBP extends util.FastLogging {
     }
   }
 
+  // This is a test for the naive sparsity for BP in Factor3 messing up results on a graph like this:
+  // Ascii diagram:
+  //
+  //          featureVariable <-- (constant)
+  //                 |
+  //     firstVar ---+--- secondVar
+
+  @Test def defaultSparsity() {
+
+    // Create the variables we'll do inference over
+
+    val firstVar = new BooleanVariable()
+    val secondVar = new BooleanVariable()
+
+    // Create a feature variable (constant during inference), with string features
+
+    val featureDomain: CategoricalDomain[String] = new CategoricalDomain[String]
+    val featuresVar = new FeatureVectorVariable[String]() {
+      override def domain: CategoricalVectorDomain[String] = new CategoricalVectorDomain[String] {
+          override def dimensionDomain = featureDomain
+        }
+    }
+
+    // put a single feature in the variable
+    // "feat1" -> 1.0
+
+    featuresVar.update(featureDomain.index("feat1"), 1.0)(null)
+
+    val model = new Model with Parameters {
+      val errorModel = new DotFamilyWithStatistics3[BooleanVariable,BooleanVariable,FeatureVectorVariable[String]] {
+        val weights = Weights(new la.DenseTensor3(2, 2, 1))
+        weights.value := Array(3.0, 1.0, 0.5, 0.5)
+      }
+      override def factors(variables: Iterable[Var]): Iterable[Factor] = {
+        List(errorModel.Factor(firstVar, secondVar, featuresVar))
+      }
+
+      // THE LACK OF "def limitedDiscreteValues12" IS THE POINT OF THIS TEST:
+      // a naive user won't override limitedDiscreteValues12
+      // they will be surprised when the BP below here doesn't work
+    }
+
+    // Do the inference over firstVar and secondVar using BP on a Tree
+    val sumExactBeliefs : Summary = BP.inferTreeSum(List(firstVar, secondVar), model)
+    // Get the marginals
+    val m1 : DiscreteMarginal1[BooleanVariable] = sumExactBeliefs.getMarginal(firstVar).get.asInstanceOf[DiscreteMarginal1[BooleanVariable]]
+    val m2 : DiscreteMarginal1[BooleanVariable] = sumExactBeliefs.getMarginal(secondVar).get.asInstanceOf[DiscreteMarginal1[BooleanVariable]]
+    assertEquals(0.8357, m1.proportions.toArray(0), 0.01)
+    assertEquals(0.1652, m1.proportions.toArray(1), 0.01)
+    assertEquals(0.6937, m2.proportions.toArray(0), 0.01)
+    assertEquals(0.3063, m2.proportions.toArray(1), 0.01)
+  }
+
   @Test def tree3() {
     val v1 = new BinVar(0)
     val v2 = new BinVar(1)


### PR DESCRIPTION
This is to avoid surprising new users.

A novice user is likely to create a Factor3 and not know to override limitedDiscreteValues12, which will cause BP to produce incorrect results silently. This fix will default to populating limitedDiscreteValues12 with a fully dense sparsity pattern, to avoid the confusion.

See discussion thread for more details about the problem: https://groups.google.com/a/factorie.cs.umass.edu/forum/#!topic/discuss/XZbIGeqlcNA