### PR TITLE
Small fix to tokenizer, ConllProperNounPhraseFinder

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/coref/MentionPhraseFinder.scala
+++ b/src/main/scala/cc/factorie/app/nlp/coref/MentionPhraseFinder.scala
@@ -57,7 +57,7 @@ object PronounFinder extends MentionPhraseFinder {
 /** Apply returns a list of proper noun phrases, given BilouConllNerTags.
     @author Andrew McCallum */
 object ConllProperNounPhraseFinder extends MentionPhraseFinder {
-  def prereqAttrs = Seq(classOf[BilouConllNerTag])
+  def prereqAttrs = Seq(classOf[BilouConllNerTag], classOf[PennPosTag])
   def apply(doc:Document): Seq[Phrase] = {
     val result = new ArrayBuffer[Phrase]
     for (section <- doc.sections; token <- section.tokens) {
@@ -75,12 +75,12 @@ object ConllProperNounPhraseFinder extends MentionPhraseFinder {
             // TODO Be more clever in determining the headTokenOffset
             val phrase = new Phrase(section, token.positionInSection, length=lookFor.positionInSection - token.positionInSection,offsetToHeadToken = -1)
             phrase.attr += new ConllPhraseEntityType(phrase, attr(1))
-            DeterministicNounPhraseTypeLabeler.process(phrase)
+            DeterministicNounPhraseTypeLabeler.process(phrase) // this requires POS tags
             result += phrase
           } else {
             val phrase = new Phrase(section, token.positionInSection, length=1,offsetToHeadToken = -1)
             phrase.attr += new ConllPhraseEntityType(phrase, attr(1))
-            DeterministicNounPhraseTypeLabeler.process(phrase)
+            DeterministicNounPhraseTypeLabeler.process(phrase) // this requires POS tags
             result += phrase
           }
         }

--- a/src/main/scala/cc/factorie/app/nlp/segment/DeterministicLexerTokenizer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/segment/DeterministicLexerTokenizer.scala
@@ -14,9 +14,7 @@ package cc.factorie.app.nlp.segment
 
 import java.io.StringReader
 
-import cc.factorie.app.nlp.{TokenString, Document, DocumentAnnotator, Token}
-
-import scala.reflect.ClassTag
+import cc.factorie.app.nlp.{Document, DocumentAnnotator, Token}
 
 /** Split a String into a sequence of Tokens.  Aims to adhere to tokenization rules used in Ontonotes and Penn Treebank.
     Note that CoNLL tokenization would use tokenizeAllDashedWords=true.
@@ -169,7 +167,7 @@ object DeterministicNormalizingTokenizer extends DeterministicLexerTokenizer(
 //    println("Tokenizing...")
     val doc = new Document(string)
     val t0 = System.currentTimeMillis()
-    DeterministicNormalizingHtmlTokenizer.process(doc)
+    DeterministicNormalizingTokenizer.process(doc)
     val time = System.currentTimeMillis()-t0
     println(s"Processed ${doc.tokenCount} tokens in ${time}ms (${doc.tokenCount.toDouble/time*1000} tokens/second)")
     println(doc.tokens.map(_.string).mkString("\n"))

--- a/src/main/scala/cc/factorie/app/nlp/segment/EnglishLexer.flex
+++ b/src/main/scala/cc/factorie/app/nlp/segment/EnglishLexer.flex
@@ -298,7 +298,7 @@ CATCHALL = \P{C}
 {DECADE} { printDebug("DECADE"); tok() }
 
 /* For some reason combining these using | makes the lexer go into an infinite loop */
-{CURRENCY1} / [^A-Z] {
+{CURRENCY1} {
   printDebug("CURRENCY")
   if(normalizeCurrency){
     yytext() match{

--- a/src/main/scala/cc/factorie/app/nlp/segment/EnglishLexer.flex
+++ b/src/main/scala/cc/factorie/app/nlp/segment/EnglishLexer.flex
@@ -298,7 +298,7 @@ CATCHALL = \P{C}
 {DECADE} { printDebug("DECADE"); tok() }
 
 /* For some reason combining these using | makes the lexer go into an infinite loop */
-{CURRENCY1} {
+{CURRENCY1} / [^A-Z] {
   printDebug("CURRENCY")
   if(normalizeCurrency){
     yytext() match{
@@ -308,7 +308,7 @@ CATCHALL = \P{C}
   }
   else tok()
 }
-{CURRENCY2} / [^A-Z] { printDebug("CURRENCY"); if(normalizeCurrency) tok(NORMALIZED_DOLLAR) else tok() }
+{CURRENCY2} / [^a-zA-Z] { printDebug("CURRENCY"); if(normalizeCurrency) tok(NORMALIZED_DOLLAR) else tok() }
 
 {HASHTAG} { printDebug("HASHTAG"); tok() }
 {ATUSER} { printDebug("ATUSER"); tok() }

--- a/src/test/scala/cc/factorie/app/nlp/segment/TestLexerTokenizer.scala
+++ b/src/test/scala/cc/factorie/app/nlp/segment/TestLexerTokenizer.scala
@@ -208,6 +208,11 @@ class TestLexerTokenizer extends JUnitSuite with FastLogging {
       src = "2012-04-05 ethno-centric art-o-torium sure. thing",
       trg = "[2012-04-05, ethno-centric, art-o-torium, sure, ., thing]"
     )
+
+    checkDeterministicLexerTokenizer(
+      src = "Half of investors expect Greece to leave the euro zone.",
+      trg = "[Half, of, investors, expect, Greece, to, leave, the, euro, zone, .]"
+    )
   }
 
   @Test def testDeterministicNormalizingTokenizer(): Unit = {


### PR DESCRIPTION
 - Fix the tokenizer so that "euro" does not get tokenized/normalized to "eur o" / "$ o"
 - Add PennPosTag as a prerequisite for ConllProperNounPhraseFinder, since it is