### PR TITLE
OntonotesChainNer should not require use of LoadOntonotes5 to train a model

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -152,7 +152,7 @@ class LabeledOntonotesNerTag(token:Token, initialCategory:String) extends Ontono
 
 class OntonotesNerSpanLabel(span:TokenSpan, initialCategory:String) extends NerSpanLabel(span, initialCategory) { def domain = OntonotesNerDomain }
 class OntonotesNerSpan(section:Section, start:Int, length:Int, category:String) extends NerSpan(section, start, length) { val label = new OntonotesNerSpanLabel(this, category) }
-class OntonotesNerSpanBuffer(spans:Iterable[OntonotesNerSpan]) extends TokenSpanBuffer[OntonotesNerSpan]
+class OntonotesNerSpanBuffer extends TokenSpanBuffer[OntonotesNerSpan]
 
 
 object BioOntonotesNerDomain extends CategoricalDomain[String] with BIO {
@@ -172,7 +172,7 @@ object BilouOntonotesNerDomain extends CategoricalDomain[String] with BILOU {
   def bilouSuffixIntValue(bilouIntValue:Int): Int = if (bilouIntValue == 0) 0 else ((bilouIntValue - 1) / 4) + 1 
   def spanList(section:Section): OntonotesNerSpanBuffer = {
     val boundaries = bilouBoundaries(section.tokens.map(_.attr[BilouOntonotesNerTag].categoryValue))
-    new OntonotesNerSpanBuffer(boundaries.map(b => new OntonotesNerSpan(section, b._1, b._2, b._3)))
+    new OntonotesNerSpanBuffer ++= boundaries.map(b => new OntonotesNerSpan(section, b._1, b._2, b._3))
   } 
 }
 class BilouOntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BilouOntonotesNerDomain }

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -305,14 +305,18 @@ class BasicOntonotesNER extends DocumentAnnotator {
     Trainer.onlineTrain(model3.parameters, examples, evaluate=evaluate)
     new java.io.PrintStream(new File("ner2-test-output")).print(sampleOutputString(testDocs.head.tokens))
   }
-  
-  def train(trainFilename:String, testFilename:String)(implicit random: scala.util.Random): Unit = {
-    val trainDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(trainFilename, nerBilou=true)
-    val testDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(testFilename, nerBilou=true)
+
+  def train(trainDocs:Seq[Document], testDocs:Seq[Document])(implicit random: scala.util.Random): Unit = {
     mainModel match {
       case model:Model2 => trainModel2(trainDocs, testDocs)
       case model:Model3 => trainModel3(trainDocs, testDocs)
     }
+  }
+  
+  def train(trainFilename:String, testFilename:String)(implicit random: scala.util.Random): Unit = {
+    val trainDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(trainFilename, nerBilou=true)
+    val testDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(testFilename, nerBilou=true)
+    train(trainDocs, testDocs)
   }
   
   // Serialization

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -142,8 +142,10 @@ class BasicOntonotesNER extends DocumentAnnotator {
         case model:Model3 => bpPredictDocument(document)
       }
       if (!alreadyHadFeatures) { document.annotators.remove(classOf[FeaturesVariable]); for (token <- document.tokens) token.attr.remove[FeaturesVariable] }
-      // Add and populated NerSpanList attr to the document 
-      document.attr.+=(new ner.OntonotesNerSpanBuffer(document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section))))
+      // Add and populated NerSpanList attr to the document
+      var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
+      println("onsb: "+onsb.size)
+      document.attr+=onsb
     }
     document
   }

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -637,7 +637,8 @@ class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
     if (document.tokenCount > 0) {
       val doc = super.process(document)
       // Add and populated NerSpanList attr to the document
-      doc.attr.+=(new ner.OntonotesNerSpanBuffer(document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section))))
+      var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
+      doc.attr+=onsb
       doc
     } else document
   }

--- a/src/test/scala/cc/factorie/app/nlp/ner/TestNerTag.scala
+++ b/src/test/scala/cc/factorie/app/nlp/ner/TestNerTag.scala
@@ -1,0 +1,24 @@
+package cc.factorie.app.nlp.ner
+
+import org.junit.{ Assert, Before, Test }
+import Assert.assertEquals
+import cc.factorie.app.nlp.Section
+import cc.factorie.app.nlp.Document
+
+class TestNerTag {
+
+    @Test
+    def testOntonotesNerSpanBufferFlatMap() = {
+        val document: Document = new Document("test text").setName("test name")
+        val section: Section = document.sections.head
+
+        val ons1: OntonotesNerSpan = new OntonotesNerSpan(section, 0, 1, "ORG") //the values don't really matter
+        val ons2: OntonotesNerSpan = new OntonotesNerSpan(section, 1, 2, "PERSON")
+        val ons3: OntonotesNerSpan = new OntonotesNerSpan(section, 2, 3, "ORG")
+        val it: Iterable[OntonotesNerSpan] = Array(ons1, ons2, ons3)
+//      var onsb: OntonotesNerSpanBuffer = new OntonotesNerSpanBuffer(it)
+        var onsb: OntonotesNerSpanBuffer = new OntonotesNerSpanBuffer ++= it
+        assertEquals(onsb.size, 3)
+    }
+
+}


### PR DESCRIPTION
This pull request provides a modest change to OntonotesChainNer that breaks the train method into two methods such that a caller can provide Document objects that have been created by some other means than being loaded from LoadOntonotes5.  The LoadOntonotes5 is rather opaque and I could not figure out how to make use of it.  However, it was relatively straightforward to load Document objects myself and train a model.  Please consider including this patch.  This contribution should be covered by Oracle's corporate contributor's agreement.  I work for Oracle Labs East with other FACTORIE contributors.  Thanks, Philip