### PR TITLE
Fix OntonotesNerSpanBuffer so that it is populated after NER is run

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -152,7 +152,7 @@ class LabeledOntonotesNerTag(token:Token, initialCategory:String) extends Ontono
 
 class OntonotesNerSpanLabel(span:TokenSpan, initialCategory:String) extends NerSpanLabel(span, initialCategory) { def domain = OntonotesNerDomain }
 class OntonotesNerSpan(section:Section, start:Int, length:Int, category:String) extends NerSpan(section, start, length) { val label = new OntonotesNerSpanLabel(this, category) }
-class OntonotesNerSpanBuffer(spans:Iterable[OntonotesNerSpan]) extends TokenSpanBuffer[OntonotesNerSpan]
+class OntonotesNerSpanBuffer extends TokenSpanBuffer[OntonotesNerSpan]
 
 
 object BioOntonotesNerDomain extends CategoricalDomain[String] with BIO {
@@ -172,7 +172,7 @@ object BilouOntonotesNerDomain extends CategoricalDomain[String] with BILOU {
   def bilouSuffixIntValue(bilouIntValue:Int): Int = if (bilouIntValue == 0) 0 else ((bilouIntValue - 1) / 4) + 1 
   def spanList(section:Section): OntonotesNerSpanBuffer = {
     val boundaries = bilouBoundaries(section.tokens.map(_.attr[BilouOntonotesNerTag].categoryValue))
-    new OntonotesNerSpanBuffer(boundaries.map(b => new OntonotesNerSpan(section, b._1, b._2, b._3)))
+    new OntonotesNerSpanBuffer ++= boundaries.map(b => new OntonotesNerSpan(section, b._1, b._2, b._3))
   } 
 }
 class BilouOntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BilouOntonotesNerDomain }

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -305,14 +305,18 @@ class BasicOntonotesNER extends DocumentAnnotator {
     Trainer.onlineTrain(model3.parameters, examples, evaluate=evaluate)
     new java.io.PrintStream(new File("ner2-test-output")).print(sampleOutputString(testDocs.head.tokens))
   }
-  
-  def train(trainFilename:String, testFilename:String)(implicit random: scala.util.Random): Unit = {
-    val trainDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(trainFilename, nerBilou=true)
-    val testDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(testFilename, nerBilou=true)
+
+  def train(trainDocs:Seq[Document], testDocs:Seq[Document])(implicit random: scala.util.Random): Unit = {
     mainModel match {
       case model:Model2 => trainModel2(trainDocs, testDocs)
       case model:Model3 => trainModel3(trainDocs, testDocs)
     }
+  }
+  
+  def train(trainFilename:String, testFilename:String)(implicit random: scala.util.Random): Unit = {
+    val trainDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(trainFilename, nerBilou=true)
+    val testDocs = cc.factorie.app.nlp.load.LoadOntonotes5.fromFilename(testFilename, nerBilou=true)
+    train(trainDocs, testDocs)
   }
   
   // Serialization

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -142,8 +142,10 @@ class BasicOntonotesNER extends DocumentAnnotator {
         case model:Model3 => bpPredictDocument(document)
       }
       if (!alreadyHadFeatures) { document.annotators.remove(classOf[FeaturesVariable]); for (token <- document.tokens) token.attr.remove[FeaturesVariable] }
-      // Add and populated NerSpanList attr to the document 
-      document.attr.+=(new ner.OntonotesNerSpanBuffer(document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section))))
+      // Add and populated NerSpanList attr to the document
+      var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
+      println("onsb: "+onsb.size)
+      document.attr+=onsb
     }
     document
   }

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -143,8 +143,7 @@ class BasicOntonotesNER extends DocumentAnnotator {
       }
       if (!alreadyHadFeatures) { document.annotators.remove(classOf[FeaturesVariable]); for (token <- document.tokens) token.attr.remove[FeaturesVariable] }
       // Add and populated NerSpanList attr to the document
-      var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
-      document.attr+=onsb
+      document.attr.+= (new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section))) 
     }
     document
   }

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -144,7 +144,6 @@ class BasicOntonotesNER extends DocumentAnnotator {
       if (!alreadyHadFeatures) { document.annotators.remove(classOf[FeaturesVariable]); for (token <- document.tokens) token.attr.remove[FeaturesVariable] }
       // Add and populated NerSpanList attr to the document
       var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
-      println("onsb: "+onsb.size)
       document.attr+=onsb
     }
     document

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -637,8 +637,7 @@ class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
     if (document.tokenCount > 0) {
       val doc = super.process(document)
       // Add and populated NerSpanList attr to the document
-      var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
-      doc.attr+=onsb
+      doc.attr.+= (new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section))) 
       doc
     } else document
   }

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -637,7 +637,8 @@ class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
     if (document.tokenCount > 0) {
       val doc = super.process(document)
       // Add and populated NerSpanList attr to the document
-      doc.attr.+=(new ner.OntonotesNerSpanBuffer(document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section))))
+      var onsb: ner.OntonotesNerSpanBuffer =new ner.OntonotesNerSpanBuffer() ++= document.sections.flatMap(section => BilouOntonotesNerDomain.spanList(section)) 
+      doc.attr+=onsb
       doc
     } else document
   }

--- a/src/test/scala/cc/factorie/app/nlp/ner/TestNerTag.scala
+++ b/src/test/scala/cc/factorie/app/nlp/ner/TestNerTag.scala
@@ -1,0 +1,24 @@
+package cc.factorie.app.nlp.ner
+
+import org.junit.{ Assert, Before, Test }
+import Assert.assertEquals
+import cc.factorie.app.nlp.Section
+import cc.factorie.app.nlp.Document
+
+class TestNerTag {
+
+    @Test
+    def testOntonotesNerSpanBufferFlatMap() = {
+        val document: Document = new Document("test text").setName("test name")
+        val section: Section = document.sections.head
+
+        val ons1: OntonotesNerSpan = new OntonotesNerSpan(section, 0, 1, "ORG") //the values don't really matter
+        val ons2: OntonotesNerSpan = new OntonotesNerSpan(section, 1, 2, "PERSON")
+        val ons3: OntonotesNerSpan = new OntonotesNerSpan(section, 2, 3, "ORG")
+        val it: Iterable[OntonotesNerSpan] = Array(ons1, ons2, ons3)
+//      var onsb: OntonotesNerSpanBuffer = new OntonotesNerSpanBuffer(it)
+        var onsb: OntonotesNerSpanBuffer = new OntonotesNerSpanBuffer ++= it
+        assertEquals(onsb.size, 3)
+    }
+
+}


### PR DESCRIPTION
When BasicOntonotesNER.process is run the document attr OntonotesNerSpanBuffer is always empty because of a bug in how that class is defined.  This pull request provides a simple fix to the class definition of OntonotesNerSpanBuffer that is modeled directly on how a similar class, ConllNerSpanBuffer, in the same source file (NerTag.scala) is implemented.  I have included a simple test that illustrates the problem.  The line that is commented in that test will compile and create a test failure without the provided changes to src/main/scala.  As it is, it illustrates that the code works correctly with the bug fix.  I have also tested this separately on an end-to-end run of an NER annotator and verified that the contents of OntonotesNerSpanBuffer are correct.  This contribution is covered by Oracle's corporate contributor's agreement. Thanks, Philip

This pull request includes the changes from my previous pull request.  I will try to be more careful about that!  