### PR TITLE
Cubbie to JSON converstion, restrict the values of IntSeq and DoubleSeq data structures

### DIFF
--- a/src/main/scala/cc/factorie/util/JsonCubbieConverter.scala
+++ b/src/main/scala/cc/factorie/util/JsonCubbieConverter.scala
@@ -12,8 +12,8 @@ object JsonCubbieConverter {
   def toJson(c:Cubbie):JObject = {
     def toJsonImpl(a:Any):JValue = a match {
       case null => JNull
-      case is:IntSeq => is._rawArray.map(toJsonImpl).toIterable  // we can do something cleverer here if we want
-      case ds:DoubleSeq => ds._rawArray.map(toJsonImpl).toIterable
+      case is:IntSeq => is._rawArray.slice(0,is.length).map(toJsonImpl).toIterable  // we can do something cleverer here if we want
+      case ds:DoubleSeq => ds._rawArray.slice(0,ds.length).map(toJsonImpl).toIterable
       case m:mutable.Map[_,_] =>
         m.toMap.map{case (k,v) => k.toString -> toJsonImpl(v)}
       case it:Iterable[_] =>


### PR DESCRIPTION
Restrict the values of IntSeq and DoubleSeq data structures included  in json string. Fixes bug in serialization when documents are empty. The minimum size of an IntSeq is 4 and this causes a violation of the assertion in SectionTokensAndSentencesSlot when the document is empty. 

If there is a more efficient or more conventional way to handle this let me know. 

Thanks!