### PR TITLE
fix of example of using classify --read-text-dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ will run 100 iterations of a sparse collapsed Gibbs sampling on all the document
 You can also train a document classifier. Assume that "sportsdir" and "politicsdir" are each directories that  contain plan text files in the categories sports and politics. Typing
 
 ```
-$ bin/fac classify --read-text-dirs sportsdir politicsdir --write-classifier mymodel.factorie
+$ bin/fac classify --read-text-dirs sportsdir,politicsdir --write-classifier mymodel.factorie
 ```
 
 will train a log-linear by maximum likelihood (MaxEnt) and save it in the file "mymodel.factorie".


### PR DESCRIPTION
classify argument `--read-text-dirs` expects dirs to be separated by "," as could be seen in `cc.factorie.app.classify.Classify`:

 `for (directory <- opts.readTextDirs.value.split(",")) {`

moreover; there should be no space; since `readTextDirs.value` contains only the first token.