### PR TITLE
Removing line, which caused compilation problem. It does not seem to be necessary after refactoring?

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/embedding/CBOW.scala
+++ b/src/main/scala/cc/factorie/app/nlp/embedding/CBOW.scala
@@ -140,7 +140,6 @@ object CBOW {
     opts.parse(args)
     val cbow = new CBOW(opts)
     if (opts.trainInput.wasInvoked) {
-      Vocabulary.opts.maxWikiPages.setValue(opts.maxWikiPages.value) // temporary kludge
       cbow.train(opts.trainInput.value)
       cbow.writeInputEmbeddings("embeddings.txt")
     } else if (opts.vocabInput.wasInvoked) {


### PR DESCRIPTION
I removed this line to try to resolve the "build failing" report from Travis. 

It seems this line is not needed after the refactoring of the embedding code? 