### PR TITLE
Fix memory allocation in qsub utils (hyperparam optimizer)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,18 @@
 #    - ./sbt compile
 #jdk:
 #    - oraclejdk8
-language: java
-before_install:
+
+script:
     - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
-after_script:
+    - mvn clean install
     - ./sbt compile
 jdk:
     - oraclejdk8
+
+#language: java
+#before_install:
+#    - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
+#after_script:
+#    - ./sbt compile
+#jdk:
+#    - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
     - ./sbt compile
 jdk:
     - oraclejdk8
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,11 @@
 # Building this way is a workaround required due to a bug in Travis
 # wherein MAVEN_OPTS are not actually set unless /etc/mavenrc is
 # removed first, see https://github.com/travis-ci/travis-ci/issues/1689
-#script:
-#    - sudo cat /proc/meminfo
-#    - sudo rm /etc/mavenrc
-#    - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
-#    - mvn clean install
-#    - ./sbt compile
-#jdk:
-#    - oraclejdk8
-
-language: java
-env:
-  global:
+script:
+    - sudo cat /proc/meminfo
+    - sudo rm /etc/mavenrc
     - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
-after_script:
+    - mvn clean install
     - ./sbt compile
 jdk:
     - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 # Building this way is a workaround required due to a bug in Travis
 # wherein MAVEN_OPTS are not actually set unless /etc/mavenrc is
 # removed first, see https://github.com/travis-ci/travis-ci/issues/1689
-script:
-    - sudo cat /proc/meminfo
-    - sudo rm /etc/mavenrc
+#script:
+#    - sudo cat /proc/meminfo
+#    - sudo rm /etc/mavenrc
+#    - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
+#    - mvn clean install
+#    - ./sbt compile
+#jdk:
+#    - oraclejdk8
+language: java
+before_install:
     - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
-    - mvn clean install
+after_script:
     - ./sbt compile
 jdk:
     - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,11 @@
 #jdk:
 #    - oraclejdk8
 
-script:
+language: java
+env:
+  global:
     - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
-    - mvn clean install
+after_script:
     - ./sbt compile
 jdk:
     - oraclejdk8
-
-#language: java
-#before_install:
-#    - export MAVEN_OPTS="-Xmx2469m -XX:MaxPermSize=512m"
-#after_script:
-#    - ./sbt compile
-#jdk:
-#    - oraclejdk8

--- a/src/main/scala/cc/factorie/util/HyperparameterSearcher.scala
+++ b/src/main/scala/cc/factorie/util/HyperparameterSearcher.scala
@@ -281,7 +281,7 @@ abstract class JobQueueExecutor(memory: Int, className: String, cores: Int = 1) 
  */
 class QSubExecutor(memory: Int, className: String, cores: Int = 1) extends JobQueueExecutor(memory, className, cores) {
   import sys.process._
-  def runJob(script: String, logFile: String) { s"qsub -pe blake $cores -sync y -l mem_token=${memory}G -cwd -j y -o $logFile -S /bin/sh $script".!! }
+  def runJob(script: String, logFile: String) { s"qsub -pe blake $cores -sync y -l mem_token=${memory}G -l mem_free=${memory}G -cwd -j y -o $logFile -S /bin/sh $script".!! }
 }
 
 /**


### PR DESCRIPTION
Add mem_free flag in addition to mem_token flag to both 1) tell grid that we're using the memory and 2) ensure that the memory is available, because for some reason these are separate things.