### PR TITLE
Bump Scala version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.majorVersion>2.11</scala.majorVersion>
-    <scala.minorVersion>.2</scala.minorVersion>
-    <scalatest.version>2.2.2</scalatest.version>
+    <scala.minorVersion>.7</scala.minorVersion>
+    <scalatest.version>2.2.5</scalatest.version>
     <junit.version>4.10</junit.version>
   </properties>
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -34,7 +34,7 @@ object FactorieBuild extends Build {
     settings(
       organization := "cc.factorie_2.11",
       version := "1.2-SNAPSHOT",
-      scalaVersion := "2.11.2",
+      scalaVersion := "2.11.7",
       // no verbose deprecation warnings, octal escapes in jflex file are too many
       scalacOptions := Seq("-unchecked", "-encoding", "utf8"),
       resolvers ++= resolutionRepos,


### PR DESCRIPTION
From 2.11.2 to 2.11.7, this is PR #309 (sbt) plus updates to pom for Maven.