### PR TITLE
Java serialization for the NER stack

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/Document.scala
+++ b/src/main/scala/cc/factorie/app/nlp/Document.scala
@@ -68,7 +68,7 @@ trait DocumentSubstring {
     "for (section <- document.sections) section.tokens.someMethodOnSeq()...".  
     
     @author Andrew McCallum */
-class Document extends DocumentSubstring with Attr with UniqueId {
+class Document extends DocumentSubstring with Attr with UniqueId with Serializable {
   /** Create a new Document, initializing it to have contents given by the argument. */
   def this(stringContents:String) = { this(); _string = stringContents }
   /** Return the "name" assigned to this Document by the 'setName' method.

--- a/src/main/scala/cc/factorie/app/nlp/Sentence.scala
+++ b/src/main/scala/cc/factorie/app/nlp/Sentence.scala
@@ -23,7 +23,8 @@ import cc.factorie.app.nlp.pos.PennPosTag
     The annotation ParseTree is stored on a Sentence.
     Unlike other TokenSpans, constructing a Sentence automatically add it to its Sections.
     @author Andrew McCallum */
-class Sentence(sec:Section, initialStart:Int, initialLength:Int) extends TokenSpan(sec, initialStart, initialLength) {
+class Sentence(sec:Section, initialStart:Int, initialLength:Int)
+  extends TokenSpan(sec, initialStart, initialLength) with Serializable {
   /** Construct a new 0-length Sentence that begins just past the current last token of the Section, and add it to the Section automatically.
       This constructor is typically used when reading labeled training data one token at a time, where we need Sentence and Token objects. */
   def this(sec:Section) = this(sec, sec.length, 0)

--- a/src/main/scala/cc/factorie/app/nlp/Token.scala
+++ b/src/main/scala/cc/factorie/app/nlp/Token.scala
@@ -29,7 +29,8 @@ import scala.collection.mutable
     Token constructors that include a tokenString automatically append the tokenString to the Document's string.
     @param stringStart The offset into the Document string of the first character of the Token.
     @param stringEnd The offset into the Document string of the character immediately after the last character of the Token. */
-class Token(val stringStart:Int, val stringEnd:Int) extends cc.factorie.app.chain.Observation[Token] with ChainLink[Token,Section] with DocumentSubstring with Attr {
+class Token(val stringStart:Int, val stringEnd:Int)
+  extends cc.factorie.app.chain.Observation[Token] with ChainLink[Token,Section] with DocumentSubstring with Attr with Serializable {
   assert(stringStart <= stringEnd)
 //  override def _setChainPosition(c:Section, p:Int): Unit = {
 //    super._setChainPosition(c, p)

--- a/src/main/scala/cc/factorie/app/nlp/TokenSpan.scala
+++ b/src/main/scala/cc/factorie/app/nlp/TokenSpan.scala
@@ -17,7 +17,8 @@ import cc.factorie.variable._
 import scala.collection.mutable
 
 /** A sub-sequence of Tokens within a Section (which is in turn part of a Document). */
-class TokenSpan(theSection:Section, initialStart:Int, initialLength:Int) extends SpanVariable[Section,Token](theSection, initialStart, initialLength) with Attr with Ordered[TokenSpan] {
+class TokenSpan(theSection:Section, initialStart:Int, initialLength:Int)
+  extends SpanVariable[Section,Token](theSection, initialStart, initialLength) with Attr with Ordered[TokenSpan] with Serializable {
   def this(tokens:Seq[Token]) = this(tokens.head.section, tokens.head.positionInSection, tokens.size)
   /** The Document Section of which this TokenSpan is a subsequence. */
   final def section = chain  // Just a convenient alias
@@ -140,7 +141,7 @@ trait TokenSpanCollection[S<:TokenSpan] extends SpanVarCollection[S, Section, To
 class TokenSpanList[S<:TokenSpan](spans:Iterable[S]) extends SpanVarList[S, Section, Token](spans) with TokenSpanCollection[S]
 
 /** A mutable collection of TokenSpans, with various methods to returns filtered sub-sets of spans based on position and class. */
-class TokenSpanBuffer[S<:TokenSpan] extends SpanVarBuffer[S, Section, Token] with TokenSpanCollection[S]
+class TokenSpanBuffer[S<:TokenSpan] extends SpanVarBuffer[S, Section, Token] with TokenSpanCollection[S] with Serializable
 
 // Cubbie storage
 

--- a/src/main/scala/cc/factorie/app/nlp/ner/ChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/ChainNer.scala
@@ -37,7 +37,12 @@ import scala.reflect.ClassTag
  * PER      f1=0.940327 p=0.955329 r=0.925788 (tp=1497 fp=70 fn=120 true=1617 pred=1567)
  *
  */
-class ConllChainNer(url: java.net.URL=null) extends ChainNer[BilouConllNerTag](BilouConllNerDomain, (t, s) => new BilouConllNerTag(t, s), l => l.token, url) {
+class ConllChainNer(url: java.net.URL=null)
+  extends ChainNer[BilouConllNerTag](
+    BilouConllNerDomain,
+    (t, s) => new BilouConllNerTag(t, s),
+    l => l.token,
+    url) with Serializable {
   def loadDocs(fileName: String): Seq[Document] = cc.factorie.app.nlp.load.LoadConll2003(BILOU=true).fromFilename(fileName)
   override def process(document:Document): Document = {
     if (document.tokenCount > 0) {
@@ -49,7 +54,7 @@ class ConllChainNer(url: java.net.URL=null) extends ChainNer[BilouConllNerTag](B
 }
 
 //TODO this serialized model doesn't exist yet?
-object ConllChainNer extends ConllChainNer(cc.factorie.util.ClasspathURL[ConllChainNer](".factorie"))
+object ConllChainNer extends ConllChainNer(cc.factorie.util.ClasspathURL[ConllChainNer](".factorie")) with Serializable
 
 
 /**

--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -88,8 +88,7 @@ class BioConllNerTag(token:Token, initialCategory:String) extends NerTag(token, 
 class LabeledBioConllNerTag(token:Token, initialCategory:String)
   extends BioConllNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 // IobConllNerDomain is defined in app.nlp.package as val IobConllNerDomain = BioConllNerDomain
-class IobConllNerTag(token:Token, initialCategory:String)
-  extends NerTag(token, initialCategory) with Serializable {
+class IobConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) with Serializable {
   def domain = IobConllNerDomain
 }
 class LabeledIobConllNerTag(token:Token, initialCategory:String)
@@ -163,22 +162,34 @@ object OntonotesEntityTypeDomain extends EnumDomain {
 }
 // OntonotesEntityType is defined in cc.factorie.app.nlp.phrase
 
-class OntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = OntonotesNerDomain }
-class LabeledOntonotesNerTag(token:Token, initialCategory:String) extends OntonotesNerTag(token, initialCategory) with CategoricalLabeling[String]
+class OntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) {
+  def domain = OntonotesNerDomain
+}
+class LabeledOntonotesNerTag(token:Token, initialCategory:String)
+  extends OntonotesNerTag(token, initialCategory) with CategoricalLabeling[String]
 
-class OntonotesNerSpanLabel(span:TokenSpan, initialCategory:String) extends NerSpanLabel(span, initialCategory) { def domain = OntonotesNerDomain }
-class OntonotesNerSpan(section:Section, start:Int, length:Int, category:String) extends NerSpan(section, start, length) { val label = new OntonotesNerSpanLabel(this, category) }
-class OntonotesNerSpanBuffer extends TokenSpanBuffer[OntonotesNerSpan]
+class OntonotesNerSpanLabel(span:TokenSpan, initialCategory:String) extends NerSpanLabel(span, initialCategory) with Serializable {
+  def domain = OntonotesNerDomain
+}
+class OntonotesNerSpan(section:Section, start:Int, length:Int, category:String)
+  extends NerSpan(section, start, length) with Serializable {
+  val label = new OntonotesNerSpanLabel(this, category)
+}
+class OntonotesNerSpanBuffer extends TokenSpanBuffer[OntonotesNerSpan] with Serializable
 
 
 object BioOntonotesNerDomain extends CategoricalDomain[String] with BIO {
   this ++= encodedTags(OntonotesNerDomain.categories)
   freeze()
 }
-class BioOntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BioOntonotesNerDomain }
-class LabeledBioOntonotesNerTag(token:Token, initialCategory:String) extends BioOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String]
-class IobOntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BioOntonotesNerDomain }
-class LabeledIobOntonotesNerTag(token:Token, initialCategory:String) extends IobOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String]
+class BioOntonotesNerTag(token:Token, initialCategory:String)
+  extends NerTag(token, initialCategory) with Serializable { def domain = BioOntonotesNerDomain }
+class LabeledBioOntonotesNerTag(token:Token, initialCategory:String)
+  extends BioOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
+class IobOntonotesNerTag(token:Token, initialCategory:String)
+  extends NerTag(token, initialCategory) with Serializable { def domain = BioOntonotesNerDomain }
+class LabeledIobOntonotesNerTag(token:Token, initialCategory:String) 
+  extends IobOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 //class BioOntonotesNerLabel(val token:Token, targetValue:String) extends NerLabel(targetValue) { def domain = BioOntonotesNerDomain }
 
 object BilouOntonotesNerDomain extends CategoricalDomain[String] with BILOU {
@@ -191,8 +202,10 @@ object BilouOntonotesNerDomain extends CategoricalDomain[String] with BILOU {
     new OntonotesNerSpanBuffer ++= boundaries.map(b => new OntonotesNerSpan(section, b._1, b._2, b._3))
   } 
 }
-class BilouOntonotesNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BilouOntonotesNerDomain }
-class LabeledBilouOntonotesNerTag(token:Token, initialCategory:String) extends BilouOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String]
+class BilouOntonotesNerTag(token:Token, initialCategory:String)
+  extends NerTag(token, initialCategory) with Serializable { def domain = BilouOntonotesNerDomain }
+class LabeledBilouOntonotesNerTag(token:Token, initialCategory:String)
+  extends BilouOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 
 object GermevalNerDomain extends CategoricalDomain[String] {
   this ++= Vector(

--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -188,7 +188,7 @@ class LabeledBioOntonotesNerTag(token:Token, initialCategory:String)
   extends BioOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 class IobOntonotesNerTag(token:Token, initialCategory:String)
   extends NerTag(token, initialCategory) with Serializable { def domain = BioOntonotesNerDomain }
-class LabeledIobOntonotesNerTag(token:Token, initialCategory:String) 
+class LabeledIobOntonotesNerTag(token:Token, initialCategory:String)
   extends IobOntonotesNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 //class BioOntonotesNerLabel(val token:Token, targetValue:String) extends NerLabel(targetValue) { def domain = BioOntonotesNerDomain }
 

--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -59,9 +59,15 @@ object ConllNerDomain extends EnumDomain {
 class ConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = ConllNerDomain }
 class LabeledConllNerTag(token:Token, initialCategory:String) extends ConllNerTag(token, initialCategory) with CategoricalLabeling[String]
 
-class ConllNerSpanLabel(span:TokenSpan, initialCategory:String) extends NerSpanLabel(span, initialCategory) { def domain = ConllNerDomain }
-class ConllNerSpan(section:Section, start:Int, length:Int, category:String) extends NerSpan(section, start, length) { val label = new ConllNerSpanLabel(this, category) }
-class ConllNerSpanBuffer extends TokenSpanBuffer[ConllNerSpan]
+class ConllNerSpanLabel(span:TokenSpan, initialCategory:String)
+  extends NerSpanLabel(span, initialCategory) with Serializable {
+  def domain = ConllNerDomain
+}
+class ConllNerSpan(section:Section, start:Int, length:Int, category:String)
+  extends NerSpan(section, start, length) with Serializable {
+  val label = new ConllNerSpanLabel(this, category)
+}
+class ConllNerSpanBuffer extends TokenSpanBuffer[ConllNerSpan] with Serializable
 //class ConllNerLabel(val token:Token, targetValue:String) extends NerLabel(targetValue) { def domain = ConllNerDomain }
 
 
@@ -76,11 +82,18 @@ object BioConllNerDomain extends CategoricalDomain[String] with BIO {
     new ConllNerSpanBuffer ++= boundaries.map(b => new ConllNerSpan(section, b._1, b._2, b._3))
   } 
 }
-class BioConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BioConllNerDomain }
-class LabeledBioConllNerTag(token:Token, initialCategory:String) extends BioConllNerTag(token, initialCategory) with CategoricalLabeling[String]
+class BioConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) with Serializable {
+  def domain = BioConllNerDomain
+}
+class LabeledBioConllNerTag(token:Token, initialCategory:String)
+  extends BioConllNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 // IobConllNerDomain is defined in app.nlp.package as val IobConllNerDomain = BioConllNerDomain
-class IobConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = IobConllNerDomain }
-class LabeledIobConllNerTag(token:Token, initialCategory:String) extends IobConllNerTag(token, initialCategory) with CategoricalLabeling[String]
+class IobConllNerTag(token:Token, initialCategory:String)
+  extends NerTag(token, initialCategory) with Serializable {
+  def domain = IobConllNerDomain
+}
+class LabeledIobConllNerTag(token:Token, initialCategory:String)
+  extends IobConllNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 //class BioConllNerLabel(val token:Token, targetValue:String) extends NerLabel(targetValue) { def domain = BioConllNerDomain }
 
 
@@ -92,8 +105,11 @@ object BilouConllNerDomain extends CategoricalDomain[String] with BILOU {
     new ConllNerSpanBuffer ++= boundaries.map(b => new ConllNerSpan(section, b._1, b._2, b._3))
   } 
 }
-class BilouConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) { def domain = BilouConllNerDomain }
-class LabeledBilouConllNerTag(token:Token, initialCategory:String) extends BilouConllNerTag(token, initialCategory) with CategoricalLabeling[String]
+class BilouConllNerTag(token:Token, initialCategory:String) extends NerTag(token, initialCategory) with Serializable {
+  def domain = BilouConllNerDomain
+}
+class LabeledBilouConllNerTag(token:Token, initialCategory:String)
+  extends BilouConllNerTag(token, initialCategory) with CategoricalLabeling[String] with Serializable
 //class BilouConllNerLabel(val token:Token, targetValue:String) extends NerLabel(targetValue) { def domain = BilouConllNerDomain }
 
 

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -15,7 +15,7 @@ import cc.factorie._
 import model._
 import variable._
 import cc.factorie.app.nlp._
-import java.io.{BufferedInputStream, BufferedOutputStream, File}
+import java.io.{Serializable, BufferedInputStream, BufferedOutputStream, File}
 import cc.factorie.util.{Logger, BinarySerializer, CubbieConversions}
 import cc.factorie.optimize.{Trainer, LikelihoodExample}
 import cc.factorie.infer.{InferByBPChain, DiscreteProposalMaximizer, MaximizeByBPChain}
@@ -24,7 +24,7 @@ import cc.factorie.model.{DotTemplateWithStatistics2, TemplateModel, DotTemplate
 
 /** A simple named entity recognizer, trained on Ontonotes data.
     It does not have sufficient features to be state-of-the-art. */
-class BasicOntonotesNER extends DocumentAnnotator {
+class BasicOntonotesNER extends DocumentAnnotator with Serializable {
   private val logger = Logger.getLogger(this.getClass.getName)
 
   def this(url:java.net.URL) = {
@@ -406,8 +406,8 @@ class BasicOntonotesNER extends DocumentAnnotator {
 }
 
 /** The default NER1 with parameters loaded from resources in the classpath. */
-object BasicOntonotesNERWSJ extends BasicOntonotesNER(cc.factorie.util.ClasspathURL[BasicOntonotesNER]("-WSJ.factorie"))
-object BasicOntonotesNER extends BasicOntonotesNER(cc.factorie.util.ClasspathURL[BasicOntonotesNER]("-Ontonotes.factorie"))
+object BasicOntonotesNERWSJ extends BasicOntonotesNER(cc.factorie.util.ClasspathURL[BasicOntonotesNER]("-WSJ.factorie")) with Serializable
+object BasicOntonotesNER extends BasicOntonotesNER(cc.factorie.util.ClasspathURL[BasicOntonotesNER]("-Ontonotes.factorie")) with Serializable
 
 object BasicOntonotesNERTrainer {
   def main(args:Array[String]): Unit = {

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -618,6 +618,11 @@ class ConllStackedChainNer(embeddingMap: SkipGramEmbedding,
   override def process(document:Document): Document = {
     if (document.tokenCount > 0) {
       val doc = super.process(document)
+      // remove computer features
+      doc.tokens.foreach { token =>
+        if (token.attr.contains(classOf[ChainNerFeatures])) token.attr.remove[ChainNerFeatures]
+        if (token.attr.contains(classOf[ChainNer2Features])) token.attr.remove[ChainNer2Features]
+      }
       // Add and populated NerSpanList attr to the document 
       doc.attr.+=(new ner.ConllNerSpanBuffer ++= document.sections.flatMap(section => BilouConllNerDomain.spanList(section)))
       doc

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -627,11 +627,6 @@ class ConllStackedChainNer(embeddingMap: SkipGramEmbedding,
   override def process(document:Document): Document = {
     if (document.tokenCount > 0) {
       val doc = super.process(document)
-      // remove computer features
-      doc.tokens.foreach { token =>
-        if (token.attr.contains(classOf[ChainNerFeatures])) token.attr.remove[ChainNerFeatures]
-        if (token.attr.contains(classOf[ChainNer2Features])) token.attr.remove[ChainNer2Features]
-      }
       // Add and populated NerSpanList attr to the document 
       doc.attr.+=(new ner.ConllNerSpanBuffer ++= document.sections.flatMap(section => BilouConllNerDomain.spanList(section)))
       doc

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -614,7 +614,16 @@ class ConllStackedChainNer(embeddingMap: SkipGramEmbedding,
                            embeddingDim: Int,
                            scale: Double,
                            useOffsetEmbedding: Boolean,
-                           url: java.net.URL=null) extends StackedChainNer[BilouConllNerTag](BilouConllNerDomain, (t, s) => new BilouConllNerTag(t, s), l => l.token, embeddingMap, embeddingDim, scale, useOffsetEmbedding, url) {
+                           url: java.net.URL=null)
+  extends StackedChainNer[BilouConllNerTag](
+    BilouConllNerDomain,
+    (t, s) => new BilouConllNerTag(t, s),
+    l => l.token,
+    embeddingMap,
+    embeddingDim,
+    scale,
+    useOffsetEmbedding,
+    url) with Serializable {
   override def process(document:Document): Document = {
     if (document.tokenCount > 0) {
       val doc = super.process(document)
@@ -630,14 +639,23 @@ class ConllStackedChainNer(embeddingMap: SkipGramEmbedding,
   }
 }
 //object ConllStackedChainNer extends ConllStackedChainNer(SkipGramEmbedding, 100, 1.0, true, ClasspathURL[ConllStackedChainNer](".factorie"))
-class NoEmbeddingsConllStackedChainNer(url:java.net.URL) extends ConllStackedChainNer(null, 0, 0.0, false, url)
-object NoEmbeddingsConllStackedChainNer extends NoEmbeddingsConllStackedChainNer(ClasspathURL[NoEmbeddingsConllStackedChainNer](".factorie"))
+class NoEmbeddingsConllStackedChainNer(url:java.net.URL) extends ConllStackedChainNer(null, 0, 0.0, false, url) with Serializable
+object NoEmbeddingsConllStackedChainNer extends NoEmbeddingsConllStackedChainNer(ClasspathURL[NoEmbeddingsConllStackedChainNer](".factorie")) with Serializable
 
 class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
                                embeddingDim: Int,
                                scale: Double,
                                useOffsetEmbedding: Boolean,
-                               url: java.net.URL=null) extends StackedChainNer[BilouOntonotesNerTag](BilouOntonotesNerDomain, (t, s) => new BilouOntonotesNerTag(t, s), l => l.token, embeddingMap, embeddingDim, scale, useOffsetEmbedding, url) {
+                               url: java.net.URL=null)
+  extends StackedChainNer[BilouOntonotesNerTag](
+    BilouOntonotesNerDomain,
+    (t, s) => new BilouOntonotesNerTag(t, s),
+    l => l.token,
+    embeddingMap,
+    embeddingDim,
+    scale,
+    useOffsetEmbedding,
+    url) with Serializable {
   override def process(document:Document): Document = {
     if (document.tokenCount > 0) {
       val doc = super.process(document)
@@ -648,8 +666,8 @@ class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
   }
 }
 
-class NoEmbeddingsOntonotesStackedChainNer(url:java.net.URL) extends OntonotesStackedChainNer(null, 0, 0.0, false, url)
-object NoEmbeddingsOntonotesStackedChainNer extends NoEmbeddingsOntonotesStackedChainNer(ClasspathURL[NoEmbeddingsOntonotesStackedChainNer](".factorie"))
+class NoEmbeddingsOntonotesStackedChainNer(url:java.net.URL) extends OntonotesStackedChainNer(null, 0, 0.0, false, url) with Serializable
+object NoEmbeddingsOntonotesStackedChainNer extends NoEmbeddingsOntonotesStackedChainNer(ClasspathURL[NoEmbeddingsOntonotesStackedChainNer](".factorie")) with Serializable
 
 class StackedChainNerOpts extends CmdOptions with SharedNLPCmdOptions{
   val trainFile =     new CmdOption("train", "eng.train", "FILE", "CoNLL formatted training file.")

--- a/src/main/scala/cc/factorie/app/nlp/pos/ChainPosTagger.scala
+++ b/src/main/scala/cc/factorie/app/nlp/pos/ChainPosTagger.scala
@@ -108,7 +108,7 @@ abstract class ChainPosTagger[A<:PosTag](val tagConstructor:(Token)=>A)(implicit
   def initPOSFeatures(sentence: Sentence): Unit
 }
 
-class WSJChainPosTagger extends ChainPosTagger((t:Token) => new PennPosTag(t, 0)) {
+class WSJChainPosTagger extends ChainPosTagger((t:Token) => new PennPosTag(t, 0)) with Serializable {
   def this(url: java.net.URL) = {
     this()  
     deserialize(url.openConnection().getInputStream)
@@ -144,7 +144,7 @@ class WSJChainPosTagger extends ChainPosTagger((t:Token) => new PennPosTag(t, 0)
 }
 object WSJChainPosTagger extends WSJChainPosTagger(ClasspathURL[WSJChainPosTagger](".factorie"))
 
-class OntonotesChainPosTagger extends ChainPosTagger((t:Token) => new PennPosTag(t, 0)) {
+class OntonotesChainPosTagger extends ChainPosTagger((t:Token) => new PennPosTag(t, 0)) with Serializable {
   def this(url: java.net.URL) = {
     this()  
     deserialize(url.openConnection().getInputStream)
@@ -178,7 +178,7 @@ class OntonotesChainPosTagger extends ChainPosTagger((t:Token) => new PennPosTag
     addNeighboringFeatureConjunctions(sentence.tokens, (t: Token) => t.attr[PosFeatures], "W=[^@]*$", List(-2), List(-1), List(1), List(-2,-1), List(-1,0))
   }
 }
-object OntonotesChainPosTagger extends OntonotesChainPosTagger(ClasspathURL[OntonotesChainPosTagger](".factorie"))
+object OntonotesChainPosTagger extends OntonotesChainPosTagger(ClasspathURL[OntonotesChainPosTagger](".factorie")) with Serializable
 
 
 class ChainPosTrainer[A<:PosTag, B<:ChainPosTagger[A]](taggerConstructor: () => B, loadingMethod:(String) => Seq[Document])(implicit ct:ClassTag[A]) extends HyperparameterMain {

--- a/src/main/scala/cc/factorie/app/nlp/pos/ForwardPosTagger.scala
+++ b/src/main/scala/cc/factorie/app/nlp/pos/ForwardPosTagger.scala
@@ -25,7 +25,7 @@ import cc.factorie.app.classify.backend.LinearMulticlassClassifier
     
     For the Viterbi-based part-of-speech tagger, see ChainPosTagger.  
     @author Andrew McCallum, */
-class ForwardPosTagger extends DocumentAnnotator {
+class ForwardPosTagger extends DocumentAnnotator with Serializable {
   private val logger = Logger.getLogger(this.getClass.getName)
 
   // Different ways to load saved parameters
@@ -423,8 +423,8 @@ class WSJForwardPosTagger(url:java.net.URL) extends ForwardPosTagger(url)
 object WSJForwardPosTagger extends WSJForwardPosTagger(cc.factorie.util.ClasspathURL[WSJForwardPosTagger](".factorie"))
 
 /** The default part-of-speech tagger, trained on all Ontonotes training data (including Wall Street Journal), with parameters loaded from resources in the classpath. */
-class OntonotesForwardPosTagger(url:java.net.URL) extends ForwardPosTagger(url) 
-object OntonotesForwardPosTagger extends OntonotesForwardPosTagger(cc.factorie.util.ClasspathURL[OntonotesForwardPosTagger](".factorie"))
+class OntonotesForwardPosTagger(url:java.net.URL) extends ForwardPosTagger(url) with Serializable
+object OntonotesForwardPosTagger extends OntonotesForwardPosTagger(cc.factorie.util.ClasspathURL[OntonotesForwardPosTagger](".factorie")) with Serializable
 
 class ForwardPosOptions extends cc.factorie.util.DefaultCmdOptions with SharedNLPCmdOptions{
   val modelFile = new CmdOption("model", "", "FILENAME", "Filename for the model (saving a trained model or reading a running model.")

--- a/src/main/scala/cc/factorie/app/nlp/pos/PosTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/pos/PosTag.scala
@@ -91,7 +91,8 @@ object PennPosDomain extends CategoricalDomain[String] {
   def isPersonalPronoun(pos: String) = pos == "PRP"
 }
 /** A categorical variable, associated with a token, holding its Penn Treebank part-of-speech category.  */
-class PennPosTag(token:Token, initialIndex:Int) extends PosTag(token, initialIndex) {
+class PennPosTag(token:Token, initialIndex:Int)
+  extends PosTag(token, initialIndex) with Serializable {
   def this(token:Token, initialCategory:String) = this(token, PennPosDomain.index(initialCategory))
   final def domain = PennPosDomain
   def isNoun = PennPosDomain.isNoun(categoryValue)
@@ -102,7 +103,8 @@ class PennPosTag(token:Token, initialIndex:Int) extends PosTag(token, initialInd
 }
 /** A categorical variable, associated with a token, holding its Penn Treebank part-of-speech category,
     which also separately holds its desired correct "target" value.  */
-class LabeledPennPosTag(token:Token, targetValue:String) extends PennPosTag(token, targetValue) with CategoricalLabeling[String]
+class LabeledPennPosTag(token:Token, targetValue:String)
+  extends PennPosTag(token, targetValue) with CategoricalLabeling[String] with Serializable
 
 
 /** The "A Universal Part-of-Speech Tagset"

--- a/src/main/scala/cc/factorie/util/Attr.scala
+++ b/src/main/scala/cc/factorie/util/Attr.scala
@@ -14,6 +14,7 @@
 package cc.factorie.util
 
 import scala.reflect.ClassTag
+import java.io._
 
 // TODO Why insist on AnyRef?  Why not just Any?  This would make app.nlp.DocumentProcessor a little cleaner. -akm
 
@@ -28,9 +29,9 @@ import scala.reflect.ClassTag
     Basic example usage: object foo extends Attr; foo.attr += "bar"; require(foo.attr[String] == "bar"); foo.attr.remove[String].
     
     @author Andrew McCallum */
-trait Attr {
+trait Attr extends Serializable {
   /** A collection of attributes, keyed by the attribute class. */
-  object attr {
+  object attr extends Serializable {
     private var _attr: Array[AnyRef] = new Array[AnyRef](2)
     /** The number of attributes present. */
     def length: Int = { var i = 0; while ((i < _attr.length) && (_attr(i) ne null)) i += 1; i }
@@ -159,6 +160,20 @@ trait Attr {
     }
    
     override def toString = values.mkString(" ")
+
+    @throws(classOf[IOException])
+    @throws(classOf[ClassNotFoundException])
+    private def writeObject(stream: ObjectOutputStream): Unit = {
+      stream.defaultWriteObject()
+      stream.writeObject(values)
+    }
+
+    @throws(classOf[IOException])
+    @throws(classOf[ClassNotFoundException])
+    private def readObject(stream: ObjectInputStream): Unit = {
+      stream.defaultReadObject()
+      stream.readObject().asInstanceOf[Seq[AnyRef]].foreach { value => attr += value }
+    }
 
   }
 


### PR DESCRIPTION
This pull request adds java serialization tags to the classes involved in NER tagging. It also contains custom serialization and deserialization methods for the Attr trait, as we found a bug in Scala's serialization implementation with inner objects (see https://issues.scala-lang.org/browse/SI-9375). Hopefully this will be patched in Scala 2.11.8 and then the extra methods can be removed.

This is some of the work Kate did over the summer. There will be another pull request relating to NER performance improvements she worked on once I've extracted it from our source tree.