### PR TITLE
Ner performance improvements

### DIFF
--- a/src/main/scala/cc/factorie/app/chain/Observation.scala
+++ b/src/main/scala/cc/factorie/app/chain/Observation.scala
@@ -102,7 +102,7 @@ object Observations {
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], offsetConjunctions:Seq[Int]*): Unit =
     addNeighboringFeatureConjunctions(observations, vf, null.asInstanceOf[Regex], offsetConjunctions:_*)
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], regex:String, offsetConjunctions:Seq[Int]*): Unit = {
-    val pattern = regex.r
+    val pattern = if (regex != null ) regex.r else null
     addNeighboringFeatureConjunctions[A](observations, vf, pattern, offsetConjunctions:_*)
   }
     /** Add new features created as conjunctions of existing features, with the given offsets, but only add features matching regex pattern. */

--- a/src/main/scala/cc/factorie/app/chain/Observation.scala
+++ b/src/main/scala/cc/factorie/app/chain/Observation.scala
@@ -17,6 +17,8 @@ import scala.collection.mutable.ArrayBuffer
 import cc.factorie.util.Attr
 import cc.factorie.variable.{AbstractChainLink, CategoricalVectorVar}
 
+import scala.util.matching.Regex
+
 /** A element of the input sequence to a linear-chain (CRF) having a string.  Its corresponding label will be an Attr attribute. */
 trait Observation[+This<:Observation[This]] extends AbstractChainLink[This] with Attr {
   this: This =>
@@ -58,10 +60,10 @@ object Observations {
     // Put the new features in the Token
     for (i <- 0 until size) vf(observations(i)) ++= extraFeatures(i)
   }
-  
+
   /** Return null if index i is out of range. */
   private def safeApply[A](s:Seq[A], i:Int): A = if (i < 0 || i > s.length-1) null.asInstanceOf[A] else s(i)
-  
+
   /** Add feature to each Observation. */
   def addFeatures[A<:Observation[A]](observations:Seq[A], vf:A=>CategoricalVectorVar[String], f1:A=>String, i1:Int): Unit = {
     for (i <- 0 until observations.length) {
@@ -80,7 +82,7 @@ object Observations {
       if (s1 != null && s2 != null) vf(o) += (s1 + "@" + i1 + "_&_" + s2 + "@" + i2)
     }
   }
-  
+
   /** Add trinary conjunction feature to each Observation. */
   def addFeatures[A<:Observation[A]](observations:Seq[A], vf:A=>CategoricalVectorVar[String], f1:A=>String, i1:Int, f2:A=>String, i2:Int, f3:A=>String, i3:Int): Unit = {
     for (i <- 0 until observations.length) {
@@ -92,15 +94,16 @@ object Observations {
     }
   }
 
-  
+
   // TODO Note that the methods below do not obey Sentence boundaries:  they will add offset conjunctions across the sentence boundary, 
   // even if "observations" contains only the words in the a Sentence.
   // Change the implementation to avoid Observation.next, and instead only use observations.apply(Int).
-  
+
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], offsetConjunctions:Seq[Int]*): Unit =
     addNeighboringFeatureConjunctions(observations, vf, null.asInstanceOf[String], offsetConjunctions:_*)
   /** Add new features created as conjunctions of existing features, with the given offsets, but only add features matching regex pattern. */
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], regex:String, offsetConjunctions:Seq[Int]*): Unit = {
+    val pattern = regex.r
     val size = observations.size
     if (size == 0) return
     val seqStart = observations.head.position
@@ -112,8 +115,11 @@ object Observations {
       val token = observations(i)
       val thisTokenNewFeatures = newFeatures(i)
       for (offsets <- offsetConjunctions)
-        thisTokenNewFeatures ++= appendConjunctions(token, seqStart, seqEnd, vf, regex, null, offsets).map(list => list.sortBy({case(f,o)=>o+f}).map({case(f,o)=> if (o == 0) f else f+"@"+o}).mkString("_&_"))
-      
+        thisTokenNewFeatures ++=
+          appendConjunctions(token, seqStart, seqEnd, vf, pattern, null, offsets)
+            .map { list =>
+            list.sortBy { case (f, o) => o + f }.map { case (f, o) => if (o == 0) f else f + "@" + o }.mkString("_&_")
+          }
       // TODO "f+o" is doing string concatenation, consider something faster
       i += 1
     }
@@ -129,13 +135,13 @@ object Observations {
   }
   // Recursive helper function for previous method, expanding out cross-product of conjunctions in tree-like fashion.
   // 't' is the Token to which we are adding features; 'existing' is the list of features already added; 'offsets' is the list of offsets yet to be added
-  private def appendConjunctions[A<:Observation[A]](t:A, seqStart:Int, seqEnd:Int, vf:A=>CategoricalVectorVar[String], regex:String, existing:ArrayBuffer[List[(String,Int)]], offsets:Seq[Int]): ArrayBuffer[List[(String,Int)]] = {
+  private def appendConjunctions[A<:Observation[A]](t:A, seqStart:Int, seqEnd:Int, vf:A=>CategoricalVectorVar[String], regex:Regex, existing:ArrayBuffer[List[(String,Int)]], offsets:Seq[Int]): ArrayBuffer[List[(String,Int)]] = {
     val result = new ArrayBuffer[List[(String,Int)]]
     val offset: Int = offsets.head
     var t2 = t.next(offset); if ((t2 ne null) && (t2.position < seqStart || t2.position >= seqEnd)) t2 = null.asInstanceOf[A]  // Don't add features beyond the boundaries of the Seq given in addNeighboringFeatureConjunctions
-    val adding: Seq[String] = 
+    val adding: Seq[String] =
       if (t2 eq null) { if (/*t.position +*/ offset < 0) List("<START>") else List("<END>") }
-      else if (regex != null) vf(t2).activeCategories.filter(str => str.matches(regex)) // Only include features that match pattern 
+      else if (regex != null) vf(t2).activeCategories.filter(str => regex.findFirstIn(str).size > 0) // Only include features that match pattern
       else vf(t2).activeCategories
     if (existing != null) {
       for (e <- existing; a <- adding) { val elt = (a,offset); if (!e.contains(elt)) result += (a,offset) :: e }
@@ -144,11 +150,11 @@ object Observations {
     }
     if (offsets.size == 1) result
     else appendConjunctions(t, seqStart, seqEnd, vf, regex, result, offsets.drop(1))
-  }  
-  
-  
-  
-  
+  }
+
+
+
+
   /** Extract a collection contiguous non-"background" labels
       @author Tim Vieira, Andrew McCallum */
   def extractContiguous[T](s:Seq[T], labeler:T=>String, background:String = "O"): Seq[(String,Seq[T])] = {
@@ -164,7 +170,7 @@ object Observations {
         } else {
           if (entity.length > 0) result += ((prevLabel, entity))
           entity = new ArrayBuffer
-          entity += token 
+          entity += token
         }
       } else {
         if (entity.length > 0) result += ((prevLabel, entity))

--- a/src/main/scala/cc/factorie/app/chain/Observation.scala
+++ b/src/main/scala/cc/factorie/app/chain/Observation.scala
@@ -100,7 +100,7 @@ object Observations {
   // Change the implementation to avoid Observation.next, and instead only use observations.apply(Int).
 
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], offsetConjunctions:Seq[Int]*): Unit =
-    addNeighboringFeatureConjunctions(observations, vf, null.asInstanceOf[String], offsetConjunctions:_*)
+    addNeighboringFeatureConjunctions(observations, vf, null.asInstanceOf[Regex], offsetConjunctions:_*)
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], regex:String, offsetConjunctions:Seq[Int]*): Unit = {
     val pattern = regex.r
     addNeighboringFeatureConjunctions[A](observations, vf, pattern, offsetConjunctions:_*)

--- a/src/main/scala/cc/factorie/app/chain/Observation.scala
+++ b/src/main/scala/cc/factorie/app/chain/Observation.scala
@@ -144,7 +144,7 @@ object Observations {
     var t2 = t.next(offset); if ((t2 ne null) && (t2.position < seqStart || t2.position >= seqEnd)) t2 = null.asInstanceOf[A]  // Don't add features beyond the boundaries of the Seq given in addNeighboringFeatureConjunctions
     val adding: Seq[String] =
       if (t2 eq null) { if (/*t.position +*/ offset < 0) List("<START>") else List("<END>") }
-      else if (regex != null) vf(t2).activeCategories.filter(str => regex.findFirstIn(str).size > 0) // Only include features that match pattern
+      else if (regex != null) vf(t2).activeCategories.filter(str => regex.findFirstIn(str).nonEmpty) // Only include features that match pattern
       else vf(t2).activeCategories
     if (existing != null) {
       for (e <- existing; a <- adding) { val elt = (a,offset); if (!e.contains(elt)) result += (a,offset) :: e }

--- a/src/main/scala/cc/factorie/app/chain/Observation.scala
+++ b/src/main/scala/cc/factorie/app/chain/Observation.scala
@@ -101,9 +101,12 @@ object Observations {
 
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], offsetConjunctions:Seq[Int]*): Unit =
     addNeighboringFeatureConjunctions(observations, vf, null.asInstanceOf[String], offsetConjunctions:_*)
-  /** Add new features created as conjunctions of existing features, with the given offsets, but only add features matching regex pattern. */
   def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], regex:String, offsetConjunctions:Seq[Int]*): Unit = {
     val pattern = regex.r
+    addNeighboringFeatureConjunctions[A](observations, vf, pattern, offsetConjunctions:_*)
+  }
+    /** Add new features created as conjunctions of existing features, with the given offsets, but only add features matching regex pattern. */
+  def addNeighboringFeatureConjunctions[A<:Observation[A]](observations:IndexedSeq[A], vf:A=>CategoricalVectorVar[String], regex:Regex, offsetConjunctions:Seq[Int]*): Unit = {
     val size = observations.size
     if (size == 0) return
     val seqStart = observations.head.position
@@ -116,7 +119,7 @@ object Observations {
       val thisTokenNewFeatures = newFeatures(i)
       for (offsets <- offsetConjunctions)
         thisTokenNewFeatures ++=
-          appendConjunctions(token, seqStart, seqEnd, vf, pattern, null, offsets)
+          appendConjunctions(token, seqStart, seqEnd, vf, regex, null, offsets)
             .map { list =>
             list.sortBy { case (f, o) => o + f }.map { case (f, o) => if (o == 0) f else f + "@" + o }.mkString("_&_")
           }

--- a/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/OntonotesChainNer.scala
@@ -190,16 +190,6 @@ class BasicOntonotesNER extends DocumentAnnotator {
       if (word.length > 5) { features += "P="+cc.factorie.app.strings.prefix(word, 4); features += "S="+cc.factorie.app.strings.suffix(word, 4) }
       if (token.isPunctuation) features += "PUNCTUATION"
       if (lexicon.NumberWords.containsLemmatizedWord(word)) features += "#WORD"
-      if (lexicon.iesl.Money.containsLemmatizedWord(word)) features += "MONEY"
-      if (lexicon.iesl.PersonFirst.containsLemmatizedWord(word)) features += "PERSON-FIRST"
-      if (lexicon.iesl.Month.containsLemmatizedWord(word)) features += "MONTH"
-      if (lexicon.iesl.PersonLast.containsLemmatizedWord(word)) features += "PERSON-LAST"
-      if (lexicon.iesl.PersonHonorific.containsLemmatizedWord(word)) features += "PERSON-HONORIFIC"
-      if (lexicon.iesl.Company.contains(token)) features += "COMPANY"
-      if (lexicon.iesl.Country.contains(token)) features += "COUNTRY"
-      if (lexicon.iesl.City.contains(token)) features += "CITY"
-      if (lexicon.iesl.PlaceSuffix.contains(token)) features += "PLACE-SUFFIX"
-      if (lexicon.iesl.USState.contains(token)) features += "USSTATE"
       //features ++= token.prevWindow(4).map(t2 => "PREVWINDOW="+simplifyDigits(t2.string).toLowerCase)
       //features ++= token.nextWindow(4).map(t2 => "NEXTWINDOW="+simplifyDigits(t2.string).toLowerCase)
     }

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -243,7 +243,7 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
 
   def initFeatures(document:Document, vf:Token=>CategoricalVectorVar[String]): Unit = {
     count=count+1
-    val tokenSequence = document.tokens.toSeq
+    val tokenSequence = document.tokens.toIndexedSeq
     /* This now does a lot of lemmatizing. It might be worth adding an extra
      * method to the lookup which pulls out the lemmatized form and creates it 
      * using the lexicon's lemmatizer if it isn't there.
@@ -368,7 +368,7 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
   def initSecondaryFeatures(document:Document, extraFeatures : Boolean = false): Unit = {
 
     document.tokens.foreach(t => t.attr[ChainNer2Features] ++= t.prevWindow(2).zipWithIndex.map(t2 => "PREVLABEL" + t2._2 + "="+t2._1.attr[L].categoryValue))
-    document.tokens.foreach(t => t.attr[ChainNer2Features] += "PREVLABELCON=" + t.prev.attr[L].categoryValue + "&" + t.string)
+    document.tokens.foreach(t => if (t.hasPrev) t.attr[ChainNer2Features] += "PREVLABELCON=" + t.prev.attr[L].categoryValue + "&" + t.string)
 
     for(t <- document.tokens) {
       if (t.sentenceHasPrev) {

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -45,6 +45,9 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
                                  scale: Double,
                                  useOffsetEmbedding: Boolean,
                                  url: java.net.URL=null)(implicit m: ClassTag[L]) extends DocumentAnnotator {
+
+  val FEATURE_PREFIX = "^[^@]*$".r
+
   object NERModelOpts {
     val argsList = new scala.collection.mutable.HashMap[String, String]()
     argsList += ("scale" -> scale.toString)
@@ -307,7 +310,7 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
         features += "CLUS="+prefix(20,clusters(rawWord))
       }
     }
-    for (sentence <- document.sentences) cc.factorie.app.chain.Observations.addNeighboringFeatureConjunctions(sentence.tokens, vf, "^[^@]*$", List(0), List(1), List(2), List(-1), List(-2))
+    for (sentence <- document.sentences) cc.factorie.app.chain.Observations.addNeighboringFeatureConjunctions(sentence.tokens, vf, FEATURE_PREFIX, List(0), List(1), List(2), List(-1), List(-2))
     // Add features for character n-grams between sizes 2 and 5
     document.tokens.foreach(t => if (t.string.matches("[A-Za-z]+")) vf(t) ++= t.charNGrams(2,5).map(n => "NGRAM="+n))
     // Add features from window of 4 words before and after

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -387,9 +387,9 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
 
     if(extraFeatures) {
       val sequences = getSequences(document)
-      val tokenToLabelMap = new scala.collection.mutable.HashMap[String, List[String]]
-      val sequenceToLabelMap = new scala.collection.mutable.HashMap[String, List[String]]
-      val subsequencesToLabelMap = new scala.collection.mutable.HashMap[String, List[String]]
+      val tokenToLabelMap = JavaHashMap[String,List[String]]()
+      val sequenceToLabelMap = JavaHashMap[String,List[String]]()
+      val subsequencesToLabelMap = JavaHashMap[String,List[String]]()
 
       for (token <- document.tokens) {
         if(tokenToLabelMap.contains(token.string))

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -46,7 +46,8 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
                                  useOffsetEmbedding: Boolean,
                                  url: java.net.URL=null)(implicit m: ClassTag[L]) extends DocumentAnnotator {
 
-  val FEATURE_PREFIX = "^[^@]*$".r
+  val FEATURE_PREFIX_REGEX = "^[^@]*$".r
+  val ALPHA_REGEX = "[A-Za-z]+".r
 
   object NERModelOpts {
     val argsList = new scala.collection.mutable.HashMap[String, String]()
@@ -310,9 +311,13 @@ class StackedChainNer[L<:NerTag](labelDomain: CategoricalDomain[String],
         features += "CLUS="+prefix(20,clusters(rawWord))
       }
     }
-    for (sentence <- document.sentences) cc.factorie.app.chain.Observations.addNeighboringFeatureConjunctions(sentence.tokens, vf, FEATURE_PREFIX, List(0), List(1), List(2), List(-1), List(-2))
-    // Add features for character n-grams between sizes 2 and 5
-    document.tokens.foreach(t => if (t.string.matches("[A-Za-z]+")) vf(t) ++= t.charNGrams(2,5).map(n => "NGRAM="+n))
+    for (sentence <- document.sentences)
+      cc.factorie.app.chain.Observations.addNeighboringFeatureConjunctions(sentence.tokens, vf, FEATURE_PREFIX_REGEX, List(0), List(1), List(2), List(-1), List(-2))
+
+    document.tokens.foreach { t =>
+      if (ALPHA_REGEX.findFirstIn(t.string).nonEmpty) vf(t) ++= t.charNGrams(2,5).map(n => "NGRAM="+n)
+    }
+
     // Add features from window of 4 words before and after
     document.tokens.foreach(t => vf(t) ++= t.prevWindow(4).map(t2 => "PREVWINDOW="+simplifyDigits(t2.string).toLowerCase))
     document.tokens.foreach(t => vf(t) ++= t.nextWindow(4).map(t2 => "NEXTWINDOW="+simplifyDigits(t2.string).toLowerCase))

--- a/src/main/scala/cc/factorie/variable/ChainVariable.scala
+++ b/src/main/scala/cc/factorie/variable/ChainVariable.scala
@@ -91,13 +91,13 @@ trait ChainLink[This<:ChainLink[This,C],C<:Chain[C,This]] extends AbstractChainL
   def chainBefore: IndexedSeq[This] = _chain.links.take(_position)
   def prevWindow(n:Int): Seq[This] = {
     var i = math.max(_position-n,  0)
-    val res = new collection.mutable.ListBuffer[This]
+    val res = new collection.mutable.ArrayBuffer[This]
     while (i <= math.max(_position-1, 0)) {res.append(chain(i)) ;i += 1}
     res
   }
   def nextWindow(n:Int): Seq[This] = {
     var i = math.min(_position+1,  _chain.length-1)
-    val res = new collection.mutable.ListBuffer[This]
+    val res = new collection.mutable.ArrayBuffer[This]
     while (i <= math.min(_position+n, _chain.length-1)) {res.append(chain(i)) ;i += 1}
     res
   }


### PR DESCRIPTION
This pull request is a few patches that Kate and I worked on over the summer to improve the runtime performance of StackedChainNER. Under profiling it bumps the speed by about 2x, without profiling it takes a test run on a single document (after warmup) from ~45s to ~12s (about 3x speedup). The regex changes make the standard ChainNER more efficient, but it doesn't seem to improve the speed of that model.

There are three groups of changes: 
-- refactoring the addNeighboringFeatureConjunctions method to take a precompiled regex rather that recompiling the same regex for each token in each document. There are stub methods for the old signatures which convert the arguments appropriately.
-- refactoring initSecondaryFeatures so it uses a hashmap rather than repeatedly counting a linked list, and moving the check to see if Brown term clusters exist outside of the for loop over tokens.
-- rewriting code that called prevWindowNum/nextWindowNum to used a zipped with index version of prevWindow/nextWindow. This reduces the number of maps over a linked list.