### PR TITLE
Lexicon bugfixes

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/lexicon/AhoCorasick.scala
+++ b/src/main/scala/cc/factorie/app/nlp/lexicon/AhoCorasick.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.Set
  */
 class AhoCorasick(val sep : String) extends Serializable {
   val root : TrieNode = new TrieNode(sep)
-  private var constructed : Boolean = false
+  @transient private var constructed : Boolean = false
   
   /** Construct an instance from a Seq of phrases. */
   def this(sep : String, lexicon : Seq[Seq[String]]) = { this(sep); this ++= lexicon }

--- a/src/main/scala/cc/factorie/app/nlp/lexicon/AhoCorasick.scala
+++ b/src/main/scala/cc/factorie/app/nlp/lexicon/AhoCorasick.scala
@@ -33,8 +33,6 @@ import scala.collection.mutable.Set
  * An implementation of the Aho-Corasick (1975) string matching automaton.
  */
 class AhoCorasick(val sep : String) extends Serializable {
-  private val logger = Logger.getLogger("cc.factorie.app.nlp.lexicon.AhoCorasick")
-  
   val root : TrieNode = new TrieNode(sep)
   private var constructed : Boolean = false
   
@@ -163,7 +161,7 @@ class AhoCorasick(val sep : String) extends Serializable {
 
   /** Adds a Seq of phrases into the current Trie, and fixes the failure transitions. */
   def ++=(input : Seq[Seq[String]]) : Unit = synchronized {
-    logger.log(Logger.INFO)("Appending to automaton")
+    AhoCorasick.logger.log(Logger.INFO)("Appending to automaton")
     for (e <- input) { root.add(e,0) }
     setTransitions()
   }
@@ -192,8 +190,13 @@ class AhoCorasick(val sep : String) extends Serializable {
   override def toString() : String = { "Aho-Corasick automaton containing " + size() + " phrases." }
   
   /** Serialization methods. Reconstructing the Trie from a source is usually faster. */
-  def writeObject(out : java.io.ObjectOutputStream) : Unit = { out.defaultWriteObject() }
-  def readObject(in : java.io.ObjectInputStream) : Unit = { in.defaultReadObject(); setTransitions() }
+  @throws(classOf[java.io.IOException])
+  @throws(classOf[ClassNotFoundException])
+  private def readObject(in: java.io.ObjectInputStream): Unit = { in.defaultReadObject(); constructed = false; setTransitions() }
+}
+
+object AhoCorasick {
+  private val logger = Logger.getLogger("cc.factorie.app.nlp.lexicon.AhoCorasick")
 }
 
 /**

--- a/src/main/scala/cc/factorie/app/nlp/lexicon/TrieNode.scala
+++ b/src/main/scala/cc/factorie/app/nlp/lexicon/TrieNode.scala
@@ -197,7 +197,9 @@ class TrieNode(val label : String, var root : TrieNode, val sep : String, val de
   /**
    * Serialization method. It's usually faster to reconstruct the Trie from the source, but this ensures compatibility.
    */
-  def readObject(in : java.io.ObjectInputStream) : Unit = { in.defaultReadObject(); failNode = root }
+  @throws(classOf[java.io.IOException])
+  @throws(classOf[ClassNotFoundException])
+  private def readObject(in : java.io.ObjectInputStream) : Unit = { in.defaultReadObject(); failNode = root }
 }
 
 object TrieNode {

--- a/src/main/scala/cc/factorie/app/nlp/lexicon/TrieNode.scala
+++ b/src/main/scala/cc/factorie/app/nlp/lexicon/TrieNode.scala
@@ -123,7 +123,7 @@ class TrieNode(val label : String, var root : TrieNode, val sep : String, val de
     if (phrase.length <= index) {
       emit = true
       exactEmit = true
-      if (output == -1) {
+      if ((output == -1) && (outputSet == null)) {
         output = depth
       } else {
         if (outputSet == null) { constructSet }
@@ -166,7 +166,7 @@ class TrieNode(val label : String, var root : TrieNode, val sep : String, val de
 
   private def constructSet() : Unit = {
     outputSet = JavaHashSet[Int](3)
-    outputSet.add(output)
+    if (output != -1) { outputSet.add(output) }
     output = -1
   }
   


### PR DESCRIPTION
These are two small bugfixes to the AhoCorasick implementation. 

The first commit fixes an issue where findMentions would occasionally hit an ArrayIndexOutOfBoundsException due to the sentinel value sometimes escaping into the outputSet. The second & third commit fixes the readObject method on AhoCorasick as Scala methods interact oddly with the JVM's serialization infrastructure.