### PR TITLE
Fixed naive bayes indexing and test.

### DIFF
--- a/src/main/scala/cc/factorie/app/classify/backend/NaiveBayes.scala
+++ b/src/main/scala/cc/factorie/app/classify/backend/NaiveBayes.scala
@@ -26,7 +26,7 @@ class NaiveBayes(var evidenceSmoothingMass: Double = 1.0) extends MulticlassClas
     // Incorporate smoothing, with simple +m smoothing
     for (li <- 0 until numLabels; fi <- 0 until numFeatures) evid(li).masses += (fi, evidenceSmoothingMass)
     // Incorporate evidence
-    for (i <- 0 until labels.length; label = labels(i); feature = features(i); w = weights(i)) {
+    for (i <- labels.indices; label = labels(i); feature = features(i); w = weights(i)) {
       feature.foreachActiveElement((featureIndex, featureValue) => {
         evid(label).masses += (featureIndex, w*featureValue)
       })
@@ -34,7 +34,7 @@ class NaiveBayes(var evidenceSmoothingMass: Double = 1.0) extends MulticlassClas
     // Put results into the model templates
     val evWeightsValue = classifier.weights.value
     for (li <- 0 until numLabels; fi <- 0 until numFeatures)
-      evWeightsValue(li * numFeatures + fi) = math.log(evid(li).apply(fi))
+      evWeightsValue(fi, li) = math.log(evid(li).apply(fi))
   }
   def newModel(featureSize: Int, labelSize: Int) = new LinearMulticlassClassifier(labelSize, featureSize)
 }

--- a/src/test/scala/cc/factorie/app/classify/backend/TestNaiveBayes.scala
+++ b/src/test/scala/cc/factorie/app/classify/backend/TestNaiveBayes.scala
@@ -64,17 +64,17 @@ class TestNaiveBayes extends JUnitSuite with cc.factorie.util.FastLogging {
     val classifier = trainer.train(people, (person: Person) => person.features)
 
     // what we expect:
-    // p(male|largeFoot)   = 3/4 = 0.75
-    // p(male|longhair)    = 1/5 = 0.2
-    // p(female|largeFoot) = 1/4 = 0.25
-    // p(female|longhair)  = 4/5 = 0.8
-    val expected = new DenseTensor2(Array(Array(math.log(0.75), math.log(0.25)), Array(math.log(0.2), math.log(0.8))))
+    // p(largeFoot|male)   = 3/4
+    // p(longhair|male)    = 1/4
+    // p(largeFoot|female) = 1/5
+    // p(longhair|female)  = 4/5
+    val expected = new DenseTensor2(Array(Array(math.log(0.75), math.log(0.2)), Array(math.log(0.25), math.log(0.8))))
     assertArrayEquals(expected.toArray, classifier.weights.value.toArray, 0.001)
 
-    // p(male|largeFoot&longHair) = 0.75 * 0.2 = 0.15
-    // p(female|largeFoot&longHair) = 0.25 * 0.8 = 0.2
+    // p(male|largeFoot&longHair) = 0.75 * 0.25 = 0.1875
+    // p(female|largeFoot&longHair) = 0.2 * 0.8 = 0.16
     val c = classifier.classify(p7)
-    assertArrayEquals(Array(math.log(0.15), math.log(0.2)), c.prediction.toArray, 0.001)
+    assertArrayEquals(Array(math.log(0.1875), math.log(0.16)), c.prediction.toArray, 0.001)
   }
 
 }


### PR DESCRIPTION
This PR addresses two issues regarding the Naive Bayes implementation:
  - The learned weights should be indexed as (Features x Labels).
  - Some inconsistencies in the test were fixed.
