### PR TITLE
StackedChainNER adds the test features before freezing the second domain

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -519,9 +519,12 @@ abstract class StackedChainNer[S <: NerSpan : ClassTag, L<:NerTag ](labelDomain:
 
     (trainDocuments ++ testDocuments).foreach( _.tokens.map(token => token.attr += new ChainNer2Features(token)))
 
-    for(document <- trainDocuments ++ testDocuments) initFeatures(document, (t:Token)=>t.attr[ChainNer2Features])
-    for(document <- trainDocuments ++ testDocuments) initSecondaryFeatures(document)
+    for(document <- trainDocuments) initFeatures(document, (t:Token)=>t.attr[ChainNer2Features])
+    for(document <- trainDocuments) initSecondaryFeatures(document)
     ChainNer2FeaturesDomain.freeze()
+      
+    for(document <- testDocuments) initFeatures(document, (t:Token)=>t.attr[ChainNer2Features])
+    for(document <- testDocuments) initSecondaryFeatures(document)
     //println(trainDocuments(3).tokens.map(token => token.nerTag.target.categoryValue + " "+token.string+" "+token.attr[ChainNer2Features].toString).mkString("\n"))
     //println("Example Test Token features")
     //println(testDocuments(1).tokens.map(token => token.nerTag.baseCategoryValue+" "+token.string+" "+token.attr[ChainNer2Features].toString).mkString("\n"))


### PR DESCRIPTION
The StackedChainNER has two feature domains, the first of which is properly frozen before the test documents' features are generated. The second domain has the features generated for both train and test documents at the same time, thus adding all the (unseen) test time features to the second domain. The model parameters for these features are all zero as they don't appear in the training set (about 6 million zeros for the Ontonotes dataset using one random split).

These zeros are part of the stored model file, which results in the OntonotesStackedChainNER model file being approx 657MB, instead of approx 598MB after this patch. The in memory representation of the StackedChainNER model decreases by the same amount.