### PR TITLE
Added a document processor to ensure that ner tags are well-formed.

### DIFF
--- a/src/main/scala/cc/factorie/app/chain/ChainModel.scala
+++ b/src/main/scala/cc/factorie/app/chain/ChainModel.scala
@@ -58,6 +58,7 @@ class ChainModel[Label <: MutableDiscreteVar, Features <: CategoricalVectorVar[S
   var useObsMarkov = false
 
   def serialize(stream: OutputStream) {
+    import cc.factorie.util.CubbieConversions._
     val dstream = new DataOutputStream(new BufferedOutputStream(stream))
     BinarySerializer.serialize(featuresDomain, dstream)
     BinarySerializer.serialize(labelDomain, dstream)
@@ -66,6 +67,7 @@ class ChainModel[Label <: MutableDiscreteVar, Features <: CategoricalVectorVar[S
   }
 
   def deserialize(stream: InputStream) {
+    import cc.factorie.util.CubbieConversions._
     val dstream = new DataInputStream(new BufferedInputStream(stream))
     BinarySerializer.deserialize(featuresDomain, dstream)
     BinarySerializer.deserialize(labelDomain, dstream)

--- a/src/main/scala/cc/factorie/app/nlp/DocumentAnnotatorPipeline.scala
+++ b/src/main/scala/cc/factorie/app/nlp/DocumentAnnotatorPipeline.scala
@@ -74,8 +74,8 @@ object DocumentAnnotatorPipeline extends FastLogging  {
     classOf[ner.NerTag] -> (() => ner.ConllChainNer), // TODO Should there be a different default?
     classOf[ner.BilouConllNerTag] -> (() => ner.NoEmbeddingsConllStackedChainNer),
     classOf[ner.BilouOntonotesNerTag] -> (() => ner.NoEmbeddingsOntonotesStackedChainNer),
-    classOf[ner.ConllNerSpanBuffer] -> (() => ner.ConllNerChunkAnnotator),
-    classOf[ner.OntonotesNerSpanBuffer] -> (() => ner.OntonotesNerChunkAnnotator),
+    classOf[ner.ConllNerSpanBuffer] -> (() => ner.BilouConllNerChunkAnnotator),
+    classOf[ner.OntonotesNerSpanBuffer] -> (() => ner.BilouOntonotesNerChunkAnnotator),
     //classOf[coref.mention.NerMentionList] -> (() => coref.mention.NerAndPronounMentionFinder),
     //classOf[phrase.GenderLabel[coref.Mention]] -> (() => phrase.GenderLabeler[]),
     classOf[phrase.Gender] -> (() => phrase.MentionPhraseGenderLabeler),

--- a/src/main/scala/cc/factorie/app/nlp/ner/NERChunkAnnotator.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NERChunkAnnotator.scala
@@ -9,9 +9,14 @@ import java.util.logging.{Logger, Level}
 /**
  * @author John Sullivan
  */
-object ConllNerChunkAnnotator extends NerChunkAnnotator({() => new ConllNerSpanBuffer}, {(s:Section, start:Int, end:Int, cat:String) => new ConllNerSpan(s, start, end, cat)})
-object OntonotesNerChunkAnnotator extends NerChunkAnnotator({() => new OntonotesNerSpanBuffer}, {(s:Section, start:Int, end:Int, cat:String) => new OntonotesNerSpan(s, start, end, cat)})
+object BilouConllNerChunkAnnotator extends NerChunkAnnotator[ConllNerSpan, BilouConllNerTag]({() => new ConllNerSpanBuffer}, {(s:Section, start:Int, end:Int, cat:String) => new ConllNerSpan(s, start, end, cat)})
+object BilouOntonotesNerChunkAnnotator extends NerChunkAnnotator[OntonotesNerSpan, BilouOntonotesNerTag]({() => new OntonotesNerSpanBuffer}, {(s:Section, start:Int, end:Int, cat:String) => new OntonotesNerSpan(s, start, end, cat)})
+object BioConllNerChunkAnnotator extends NerChunkAnnotator[ConllNerSpan, BioConllNerTag]({() => new ConllNerSpanBuffer}, {(s:Section, start:Int, end:Int, cat:String) => new ConllNerSpan(s, start, end, cat)})
+object BioOntonotesNerChunkAnnotator extends NerChunkAnnotator[OntonotesNerSpan, BioOntonotesNerTag]({() => new OntonotesNerSpanBuffer}, {(s:Section, start:Int, end:Int, cat:String) => new OntonotesNerSpan(s, start, end, cat)})
 
+
+/** Takes documents that are already annotated with token-level NerTags of type Tag and annotates them with NerSpans
+  * of type Span */
 class NerChunkAnnotator[Span <: NerSpan : ClassTag, Tag <: NerTag : ClassTag](newBuffer:() => NerSpanBuffer[Span], newSpan:(Section, Int, Int, String) => Span) extends DocumentAnnotator {
 
   private val logger = Logger.getLogger(getClass.getName)

--- a/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/NerTag.scala
@@ -14,7 +14,9 @@
 package cc.factorie.app.nlp.ner
 
 import cc.factorie.app.nlp._
+import cc.factorie.la.{SparseBinaryTensor2, Tensor2}
 import cc.factorie.variable._
+import scala.collection.JavaConverters._
 
 // A "Tag" is a categorical label associated with a token.
 
@@ -47,14 +49,96 @@ abstract class NerSpan(section:Section, start:Int, length:Int) extends TokenSpan
   * @author Kate Silverstein
   */
 trait SpanEncoding {
+  this: CategoricalDomain[String] =>
   def prefixes: Set[String]
   def encodedTags(baseTags: Seq[String]): Seq[String] = Seq("O") ++ baseTags.filter(_ != "O").flatMap(t => prefixes.map(_ + t))
   def suffixIntVal(i: Int): Int = if (i == 0) 0 else ((i - 1)/prefixes.size)+1
+  def isLicitTransition(from:String, to:String):Boolean
+
+  def isLicit(from:this.type#Value, to:this.type#Value):Boolean
+
+  final def permittedMask:Set[(Int, Int)] =
+    (for(t1 <- this._indices.values().asScala; // todo there has to be a better way to get this
+        t2 <- this._indices.values().asScala
+        if isLicit(t1, t2)) yield {
+      //println(s"${t1.category} -> ${t2.category}")
+      t1.intValue -> t2.intValue }).toSet
 }
+object BILOU {
+  val licitTransitions = Set(
+    "O" -> "B",
+    "O" -> "U",
+    "O" -> "O",
+
+    "B" -> "I",
+    "B" -> "L",
+
+    "I" -> "I",
+    "I" -> "L",
+
+    "L" -> "O",
+    "L" -> "B",
+    "L" -> "U",
+
+    "U" -> "U",
+    "U" -> "B",
+    "U" -> "O"
+  )
+}
+
+object BIO {
+  val licitTransitions = Set(
+    "B" -> "I",
+    "B" -> "O",
+    "B" -> "B",
+
+    "O" -> "B",
+    "O" -> "O",
+
+    "I" -> "I",
+    "I" -> "O",
+    "I" -> "B"
+  )
+}
+
 /** BILOU span encoding (Beginning, Inside, Last, Outside, Unit) */
-trait BILOU extends SpanEncoding { def prefixes = Set("B-", "I-", "L-", "U-") }
+trait BILOU extends SpanEncoding {
+  this : CategoricalDomain[String] =>
+  def prefixes = Set("B-", "I-", "L-", "U-")
+  def isLicitTransition(from: String, to: String) = BILOU.licitTransitions contains from -> to
+
+  def splitNerTag(tag:String):(String, Option[String]) = if(tag == "O") "O" -> None else {
+    val Array(pre, cat) = tag.split("-")
+    if(pre == "U") {
+      pre -> None
+    } else {
+      pre -> Some(cat)
+    }
+  }
+
+  def isLicit(from: this.type#Value, to: this.type#Value) =
+    splitNerTag(from.category) -> splitNerTag(to.category) match {
+      case ((fromPre, Some(fromCat)), (toPre, Some(toCat))) => toCat == fromCat && BILOU.licitTransitions.contains(fromPre -> toPre)
+      case ((fromPre, _), (toPre, _)) => BILOU.licitTransitions contains fromPre -> toPre
+    }
+
+}
 /** BIO span encoding (Beginning, Inside, Outside) */
-trait BIO extends SpanEncoding { def prefixes = Set("B-", "I-") }
+trait BIO extends SpanEncoding {
+  this : CategoricalDomain[String] =>
+  def prefixes = Set("B-", "I-")
+  def isLicitTransition(from: String, to: String) = BILOU.licitTransitions contains from -> to
+  def splitNerTag(tag:String):(String, Option[String]) = if(tag == "O") "O" -> None else {
+    val Array(pre, cat) = tag.split("-")
+    pre -> Some(cat)
+  }
+
+  def isLicit(from: this.type#Value, to: this.type#Value) =
+    splitNerTag(from.category) -> splitNerTag(to.category) match {
+      case ((fromPre, Some(fromCat)), (toPre, Some(toCat))) => toCat == fromCat && BIO.licitTransitions.contains(fromPre -> toPre)
+      case ((fromPre, _), (toPre, _)) => BIO.licitTransitions contains fromPre -> toPre
+    }
+}
 
 object ConllNerDomain extends EnumDomain {
   val O, PER, ORG, LOC, MISC = Value

--- a/src/main/scala/cc/factorie/app/nlp/ner/WellFormedNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/WellFormedNer.scala
@@ -1,0 +1,48 @@
+package cc.factorie.app.nlp.ner
+
+import cc.factorie.app.chain.{ChainHelper, ChainCliqueValues}
+import cc.factorie.app.nlp.{Document, Token, DocumentAnnotator}
+import cc.factorie.la.{Tensor2, DenseTensor2}
+
+import scala.reflect.{ClassTag, classTag}
+
+/**
+ * Takes an Ner annotator and returns a document annotator that produces only annotations that are well-formed according
+ * to the permittedMask on the labelDomain. This is a prerequisite to NerChunkAnnotator in general
+ * @author johnsullivan
+ */
+class WellFormedNer[Tag <: NerTag : ClassTag](ner:ChainNer[Tag]) extends DocumentAnnotator {
+  println("using well-formed Ner")
+
+  lazy val prereqAttrs = ner.prereqAttrs
+  lazy val postAttrs = ner.postAttrs
+
+  def tokenAnnotationString(token: Token) = ner.tokenAnnotationString(token)
+
+  private val maskedTransitions:Tensor2 = {
+    val mt = new DenseTensor2(ner.labelDomain.dimensionSize, ner.labelDomain.dimensionSize, Double.NegativeInfinity)
+    ner.labelDomain.permittedMask.foreach { case (i, j) =>
+      mt.update(i,j, 0.0)
+    }
+    (mt + ner.model.markov.weights.value).asInstanceOf[Tensor2]
+  }
+
+  private def maximizeWellFormed(vars:Seq[Tag]): Unit = {
+    val result = ChainHelper.viterbiFast(ChainCliqueValues(ner.model.getLocalScores(vars), Seq.fill(math.max(1, vars.size - 1))(maskedTransitions)))
+    vars.indices.foreach(i => vars(i).set(result.mapValues(i))(null))
+  }
+
+  def process(document: Document) = {
+    if (!document.tokens.head.attr.contains(classTag[Tag].runtimeClass))
+      document.tokens.map(token => token.attr += ner.newLabel(token, "O"))
+    if (!document.tokens.head.attr.contains(classOf[ner.ChainNERFeatures])) {
+      document.tokens.map(token => {token.attr += new ner.ChainNERFeatures(token)})
+      ner.addFeatures(document, (t:Token)=>t.attr[ner.ChainNERFeatures])
+    }
+    document.tokens.foreach(_.attr[Tag].setCategory("O")(null))
+    document.sentences.collect { case s if s.size > 1 =>
+      maximizeWellFormed(s.tokens.map(_.attr[Tag]))
+    }
+    document
+  }
+}


### PR DESCRIPTION
The meat here is `cc.factorie.app.nlp.ner.WellFormedNer` which takes a `ChainNer` (it is easily adaptable to `StackedChainNer`) and processes a document by annotating it exactly as it's instance of `ChainNer` would, except that it only permits licit transitions as defined by the label domain (see `cc.factorie.app.nlp.ner.SpanEncoding`).

This exists primarily to make things easy for `cc.factorie.app.nlp.ner.NerChunkAnnotator`, and should, in general, process a document before it.