### PR TITLE
Fix sampleindex for SparseDoubleSeq

### DIFF
--- a/src/main/scala/cc/factorie/util/DoubleSeq.scala
+++ b/src/main/scala/cc/factorie/util/DoubleSeq.scala
@@ -259,9 +259,9 @@ trait SparseDoubleSeq extends DoubleSeq {
   def containsNaN: Boolean = { foreachActiveElement((i,v) => if (v != v) return true); false }
   def sampleIndex(normalizer:Double)(implicit r:Random): Int = {
     assert(normalizer > 0.0, "normalizer = "+normalizer)
-    var b = 0.0; val s = r.nextDouble * normalizer
-    foreachActiveElement((i,v) => { assert(v >= 0.0); if (b > s) return i - 1; b += v })
-    length - 1
+    var li = 0; var b = 0.0; val s = r.nextDouble * normalizer
+    foreachActiveElement((i,v) => { assert(v >= 0.0); if (b > s) return li; b += v; li = i })
+    li
   }
   /** Assumes that the values are already normalized to sum to 1. */
   override def entropy: Double = {

--- a/src/test/scala/cc/factorie/util/TestDoubleSeq.scala
+++ b/src/test/scala/cc/factorie/util/TestDoubleSeq.scala
@@ -1,0 +1,49 @@
+package cc.factorie.util
+
+import cc.factorie.la.{SparseTensor1, Tensor1}
+import org.scalatest._
+
+class TestDoubleSeq extends FlatSpec with Matchers {
+
+  val nSamples = 1e7.toInt
+
+  implicit val random = scala.util.Random
+
+  "DenseDoubleSeq.sampleIndex" should "always sample a correct index" in {
+
+    val masses = Array[Double](3, 0, 1, 0, 1, 0, 1, 0)
+    val totalMass = masses.sum
+    val props = masses.map(_ / totalMass)
+
+    val seq = new ArrayDoubleSeq(masses)
+
+    val samples = (1 to nSamples).foldLeft(Array.fill(masses.size)(0.0)) { case (acc, i) =>
+      acc(seq.sampleIndex(totalMass)) += 1.0
+      acc
+    } map (_ / nSamples)
+
+    (Tensor1(props:_*) - Tensor1(samples:_*)).twoNorm should be <= 1e-2
+
+  }
+
+  "SparseDoubleSeq.sampleIndex" should "always sample a correct index" in {
+
+    val masses = Array[Double](3, 0, 1, 0, 1, 0, 1, 0)
+    val totalMass = masses.sum
+    val props = masses.map(_ / totalMass)
+
+    val seq = new SparseTensor1(masses.size)
+    masses.zipWithIndex foreach { case (v, i) =>
+      seq += (i, v)
+    }
+
+    val samples = (1 to nSamples).foldLeft(Array.fill(masses.size)(0.0)) { case (acc, i) =>
+      acc(seq.sampleIndex(totalMass)) += 1.0
+      acc
+    } map (_ / nSamples)
+
+    (Tensor1(props:_*) - Tensor1(samples:_*)).twoNorm should be <= 1e-2
+
+  }
+
+}

--- a/src/test/scala/cc/factorie/util/TestDoubleSeq.scala
+++ b/src/test/scala/cc/factorie/util/TestDoubleSeq.scala
@@ -11,7 +11,7 @@ class TestDoubleSeq extends FlatSpec with Matchers {
 
   "DenseDoubleSeq.sampleIndex" should "always sample a correct index" in {
 
-    val masses = Array[Double](3, 0, 1, 0, 1, 0, 1, 0)
+    val masses = Array[Double](0, 10, 0, 1, 0)
     val totalMass = masses.sum
     val props = masses.map(_ / totalMass)
 
@@ -28,7 +28,7 @@ class TestDoubleSeq extends FlatSpec with Matchers {
 
   "SparseDoubleSeq.sampleIndex" should "always sample a correct index" in {
 
-    val masses = Array[Double](3, 0, 1, 0, 1, 0, 1, 0)
+    val masses = Array[Double](0, 10, 0, 1, 0)
     val totalMass = masses.sum
     val props = masses.map(_ / totalMass)
 


### PR DESCRIPTION
This fixes a bug with SparseDoubleSeq.sampleIndex. Since only active elements are iterated, the last index needs to be carried with the sweep. Note that SparseDoubleSeq is tested via the cc.factorie.la.SparseTensor1 implementation.