### PR TITLE
Bumping Scala version to 2.11.8 to fix SI-9375

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@ limitations under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scala.majorVersion>2.10</scala.majorVersion>
-    <scala.minorVersion>.6</scala.minorVersion>
+    <scala.majorVersion>2.11</scala.majorVersion>
+    <scala.minorVersion>.7</scala.minorVersion>
     <scalatest.version>2.2.5</scalatest.version>
     <junit.version>4.10</junit.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.majorVersion>2.11</scala.majorVersion>
-    <scala.minorVersion>.7</scala.minorVersion>
+    <scala.minorVersion>.8</scala.minorVersion>
     <scalatest.version>2.2.5</scalatest.version>
     <junit.version>4.10</junit.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@ limitations under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scala.majorVersion>2.11</scala.majorVersion>
-    <scala.minorVersion>.7</scala.minorVersion>
+    <scala.majorVersion>2.10</scala.majorVersion>
+    <scala.minorVersion>.6</scala.minorVersion>
     <scalatest.version>2.2.5</scalatest.version>
     <junit.version>4.10</junit.version>
   </properties>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ import AssemblyKeys._
 
 object Versions{
   val scalaMajorVersion = "2.11"
-  val scalaMinorVersion = "7"
+  val scalaMinorVersion = "8"
   val factorieVersion = "1.2-SNAPSHOT"
 }
 

--- a/src/main/scala/cc/factorie/util/Attr.scala
+++ b/src/main/scala/cc/factorie/util/Attr.scala
@@ -13,8 +13,6 @@
 
 package cc.factorie.util
 
-import java.io._
-
 import scala.reflect.ClassTag
 
 // TODO Why insist on AnyRef?  Why not just Any?  This would make app.nlp.DocumentProcessor a little cleaner. -akm
@@ -169,20 +167,6 @@ trait Attr extends Serializable {
     }
    
     override def toString = values.mkString(" ")
-
-    @throws(classOf[IOException])
-    @throws(classOf[ClassNotFoundException])
-    private def writeObject(stream: ObjectOutputStream): Unit = {
-      stream.defaultWriteObject()
-      stream.writeObject(values)
-    }
-
-    @throws(classOf[IOException])
-    @throws(classOf[ClassNotFoundException])
-    private def readObject(stream: ObjectInputStream): Unit = {
-      stream.defaultReadObject()
-      stream.readObject().asInstanceOf[Seq[AnyRef]].foreach { value => attr += value }
-    }
 
   }
 

--- a/src/main/scala/cc/factorie/util/JsonCubbieConverter.scala
+++ b/src/main/scala/cc/factorie/util/JsonCubbieConverter.scala
@@ -63,7 +63,7 @@ object JsonCubbieConverter {
       case JDouble(d) => d
       case JBool(b) => b
       case JString(s) => s
-      case JDecimal(d) => if(d.isValidDouble){
+      case JDecimal(d) => if(d.isDecimalDouble){
         d.toDouble
       } else {
         d

--- a/src/main/scala/cc/factorie/util/JsonCubbieConverter.scala
+++ b/src/main/scala/cc/factorie/util/JsonCubbieConverter.scala
@@ -63,7 +63,7 @@ object JsonCubbieConverter {
       case JDouble(d) => d
       case JBool(b) => b
       case JString(s) => s
-      case JDecimal(d) => if(d.isDecimalDouble){
+      case JDecimal(d) => if(d.isValidDouble){
         d.toDouble
       } else {
         d


### PR DESCRIPTION
This bumps the Scala version to 2.11.8, and removes the workaround we patched in to the java.io.Serialization of Attr objects.

It's not actually listed as being a bug fixed in Scala 2.11.8 due to a JIRA oddity, but the backport commit for it is https://github.com/scala/scala/pull/4757 and I've verified the fix is in the binary from scala-lang.org.