### PR TITLE
Adding bounds checks to Tensor{2,3,4}

### DIFF
--- a/src/main/scala/cc/factorie/la/Tensor2.scala
+++ b/src/main/scala/cc/factorie/la/Tensor2.scala
@@ -39,9 +39,9 @@ trait Tensor2 extends Tensor {
     }
     ret
   }
-  def apply(i:Int, j:Int): Double = apply(i*dim2 + j)
+  def apply(i:Int, j:Int): Double = apply(singleIndex(i,j))
   def apply(i:Int): Double //= apply(i % dim1, i / dim2)
-  def update(i:Int, j:Int, v:Double): Unit = update(i*dim2 + j, v)
+  def update(i:Int, j:Int, v:Double): Unit = update(singleIndex(i,j), v)
   def +=(i:Int, j:Int, v:Double): Unit = +=(singleIndex(i, j), v)
 
   def *(t: Tensor1): Tensor1 = {
@@ -144,7 +144,15 @@ trait Tensor2 extends Tensor {
     (0 until dim1).map(n => apply(n, n)).sum
   }
   @inline final def length = dim1 * dim2
-  @inline final def singleIndex(i:Int, j:Int): Int = i*dim2 + j
+  @inline final def singleIndex(i:Int, j:Int): Int = {
+    if ((i < 0) || (j < 0)) {
+      throw new IndexOutOfBoundsException("Negative indices are not allowed, ("+i+","+j+") supplied.")
+    } else if ((i >= dim1) || (j >= dim2)) {
+      throw new IndexOutOfBoundsException("Indices ("+i+","+j+") are out of bounds for Tensor2("+dim1+","+dim2+")")
+    } else {
+      i*dim2 + j
+    }
+  }
   @inline final def multiIndex(i:Int): (Int, Int) = (i/dim2, i%dim2)
   @inline final def index1(i:Int): Int = i/dim2
   @inline final def index2(i:Int): Int = i%dim2

--- a/src/main/scala/cc/factorie/la/Tensor3.scala
+++ b/src/main/scala/cc/factorie/la/Tensor3.scala
@@ -32,11 +32,19 @@ trait Tensor3 extends Tensor {
     case t:Tensor3 => require(t.dim1 == dim1 && t.dim2 == dim2 && t.dim3 == dim3)
     case _ => throw new Error("Tensor ranks do not match.")
   }
-  def apply(i:Int, j:Int, k:Int): Double = apply(i*dim2*dim3 + j*dim3 + k)
-  def update(i:Int, j:Int, k:Int, v:Double): Unit = update(i*dim2*dim3 + j*dim3 + k, v)
+  def apply(i:Int, j:Int, k:Int): Double = apply(singleIndex(i,j,k))
+  def update(i:Int, j:Int, k:Int, v:Double): Unit = update(singleIndex(i,j,k),v)
   def +=(i:Int, j:Int, k:Int, v:Double): Unit = +=(singleIndex(i, j, k), v)
   @inline final def length = dim1 * dim2 * dim3
-  @inline final def singleIndex(i:Int, j:Int, k:Int): Int = i*dim2*dim3 + j*dim3 + k 
+  @inline final def singleIndex(i:Int, j:Int, k:Int): Int = {
+    if ((i < 0) || (j < 0) || (k < 0)) {
+      throw new IndexOutOfBoundsException("Negative indices are not allowed, ("+i+","+j+","+k+") supplied.")
+    } else if ((i >= dim1) || (j >= dim2) || (k >= dim3)) {
+      throw new IndexOutOfBoundsException("Indices ("+i+","+j+","+k+") are out of bounds for Tensor3("+dim1+","+dim2+","+dim3+")")
+    } else {
+      i*dim2*dim3 + j*dim3 + k
+    }
+  }
   @inline final def multiIndex(i:Int): (Int, Int, Int) = (i/dim2/dim3, (i/dim3)%dim2, i%dim3)
   @inline final def index1(i:Int): Int = i/dim2/dim3
   @inline final def index2(i:Int): Int = (i/dim3)%dim2

--- a/src/main/scala/cc/factorie/la/Tensor4.scala
+++ b/src/main/scala/cc/factorie/la/Tensor4.scala
@@ -34,11 +34,19 @@ trait Tensor4 extends Tensor {
     case t:Tensor4 => require(t.dim1 == dim1 && t.dim2 == dim2 && t.dim3 == dim3 && t.dim4 == dim4)
     case _ => throw new Error("Tensor ranks do not match.")
   }
-  def apply(i:Int, j:Int, k:Int, l:Int): Double = apply(i*dim2*dim3*dim4 + j*dim3*dim4 + k*dim4 + l)
-  def update(i:Int, j:Int, k:Int, l:Int, v:Double): Unit = update(i*dim2*dim3*dim4 + j*dim3*dim4 + k*dim4 + l, v)
+  def apply(i:Int, j:Int, k:Int, l:Int): Double = apply(singleIndex(i,j,k,l))
+  def update(i:Int, j:Int, k:Int, l:Int, v:Double): Unit = update(singleIndex(i,j,k,l), v)
   def +=(i:Int, j:Int, k:Int, l:Int, v:Double): Unit = +=(singleIndex(i, j, k, l), v)
   @inline final def length = dim1 * dim2 * dim3 * dim4
-  @inline final def singleIndex(i:Int, j:Int, k:Int, l:Int): Int = i*dim2*dim3*dim4 + j*dim3*dim4 + k*dim4 + l
+  @inline final def singleIndex(i:Int, j:Int, k:Int, l:Int): Int = {
+    if ((i < 0) || (j < 0) || (k < 0) || (l < 0)) {
+      throw new IndexOutOfBoundsException("Negative indices are not allowed, ("+i+","+j+","+k+","+l+") supplied.")
+    } else if ((i >= dim1) || (j >= dim2) || (k >= dim3) || (l >= dim4)) {
+      throw new IndexOutOfBoundsException("Indices ("+i+","+j+","+k+","+l+") are out of bounds for Tensor4("+dim1+","+dim2+","+dim3+","+dim4+")")
+    } else {
+      i*dim2*dim3*dim4 + j*dim3*dim4 + k*dim4 + l
+    }
+  }
   @inline final def multiIndex(i:Int): (Int, Int, Int, Int) = (i/dim2/dim3/dim4, (i/dim3/dim4)%dim2, (i/dim4)%dim3, i%dim4)
   @inline final def index1(i:Int): Int = i/dim2/dim3/dim4
   @inline final def index2(i:Int): Int = (i/dim3/dim4)%dim2


### PR DESCRIPTION
This commit adds bounds checking to the base multidimensional Tensor classes (i.e. Tensor2, Tensor3, Tensor4). It closes issue #359. All the unit tests pass, and it catches our issue where we'd transposed the indices.

All Tensor accesses through apply, update or += are now routed through singleIndex to calculate the index into the 1d backing array, and that method throws IndexOutOfBoundsException if the indices are negative or beyond the bounds of the array. 