### PR TITLE
Fixes - File name too long during build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <description>FACTORIE is a toolkit for deployable probabilistic modeling, implemented as a software library in Scala. It provides its users with a succinct language for creating relational factor graphs, estimating parameters and performing inference.</description>
   <url>http://factorie.cs.umass.edu</url>
   <groupId>cc.factorie</groupId>
-  <artifactId>factorie_${scala.majorVersion}</artifactId>
+  <artifactId>factorie_2.11</artifactId>
   <version>1.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <inceptionYear>2009</inceptionYear>
@@ -277,6 +277,10 @@ limitations under the License.
             <recompileMode>incremental</recompileMode>
             <useZincServer>false</useZincServer>
             <scalaVersion>${scala.majorVersion}${scala.minorVersion}</scalaVersion>
+            <args>
+              <arg>-Xmax-classfile-name</arg>
+              <arg>100</arg>
+            </args>
           </configuration>
         </plugin>
 
@@ -367,7 +371,7 @@ limitations under the License.
               </executions>
               <configuration>
                 <instructions>
-                  <Bundle-SymbolicName>${pom.groupId}</Bundle-SymbolicName>
+                  <Bundle-SymbolicName>${project.groupId}</Bundle-SymbolicName>
                   <Import-Package>
                     scala,
                     scala.collection,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,7 @@ object FactorieBuild extends Build {
       version := Versions.factorieVersion,
       scalaVersion := s"${Versions.scalaMajorVersion}.${Versions.scalaMinorVersion}",
       // no verbose deprecation warnings, octal escapes in jflex file are too many
-      scalacOptions := Seq("-unchecked", "-encoding", "utf8"),
+      scalacOptions := Seq("-Xmax-classfile-name", "100", "-unchecked", "-encoding", "utf8"),
       resolvers ++= resolutionRepos,
       libraryDependencies ++= Seq(
         CompileDependencies.mongodb,


### PR DESCRIPTION
Fixes - File name too long when compiling. This can happen on encrypted or legacy file systems.  Please see SI-3623 for more details.
Removes - the following Maven build warnings
[WARNING] 'artifactId' contains an expression but should be a constant. @ cc.factorie:factorie_${scala.majorVersion}:1.3-SNAPSHOT, /home/sullija/java/workspace/factorie/pom.xml, line 23, column 15
[WARNING] The expression ${pom.groupId} is deprecated. Please use ${project.groupId} instead.