### PR TITLE
Phrase head token offset change to support pos tags other than penn pos tag.

### DIFF
--- a/src/main/scala/cc/factorie/app/nlp/phrase/Phrase.scala
+++ b/src/main/scala/cc/factorie/app/nlp/phrase/Phrase.scala
@@ -14,10 +14,8 @@
 package cc.factorie.app.nlp.phrase
 
 import cc.factorie.app.nlp._
-import cc.factorie.util.Attr
-import cc.factorie.app.nlp.pos.{PennPosTag, PennPosDomain}
 import cc.factorie.app.nlp.parse.ParseTreeLabelDomain
-import cc.factorie.app.nlp.pos.{PennPosDomain, PennPosTag}
+import cc.factorie.app.nlp.pos._
 import cc.factorie.util.Attr
 
 /** A Phrase is a TokenSpan that has a head token.
@@ -82,7 +80,19 @@ object HeadTokenOffset {
       val prepositionIndex = span.indexWhere(cc.factorie.app.nlp.lexicon.Preposition.contains(_))
       if (prepositionIndex >= 1) return prepositionIndex - 1
       // If there is noun, return the last noun
-      val lastNounIndex = span.lastIndexWhere(_.attr[PennPosTag].isNoun)
+      val lastNounIndex = span.lastIndexWhere(_.attr.get[PosTag] match {
+        case None =>
+          false
+        case Some(tag) =>
+          tag match {
+            case penn: PennPosTag =>
+              penn.isNoun
+            case spa: SpanishPosTag =>
+              spa.isNoun
+            case _ =>
+              false
+          }
+      } )
       if (lastNounIndex > 0) return lastNounIndex
       // Otherwise simply select the last word of the span
       else return span.length-1


### PR DESCRIPTION
I'm very open to suggestions for better ways to handle this. This PR also does not take care of other methods on the phrase class that use the Penn POS Tag exclusively. 