### PR TITLE
reimplemented simplifyStrings for speed and correct behavior

### DIFF
--- a/src/main/scala/cc/factorie/app/strings/package.scala
+++ b/src/main/scala/cc/factorie/app/strings/package.scala
@@ -81,13 +81,13 @@ package object strings {
   def simplifyDigits(s: String): String = {
     if(s == null || s.length() == 0) {
 	    s
-	  }
+    }
     else if(isYear(s)) {
       "<YEAR>"
-	  }
+    }
     else if(isNumber(s)) {
 	    "<NUM>"
-	  }
+    }
     else {
       replaceDigits2(s)
     }

--- a/src/main/scala/cc/factorie/app/strings/package.scala
+++ b/src/main/scala/cc/factorie/app/strings/package.scala
@@ -78,60 +78,58 @@ package object strings {
   }
 
   
-    def simplifyDigits(s: String): String = {
-	    if(s == null || s.length() == 0) {
-	        return s
-	    }
-	    
-	    if(isYear(s)) {
-	        return "<YEAR>";
-	    }
-        
-	    if(isNumber(s)) {
-	        return "<NUM>";
-	    }
-	    
-	    replaceDigits2(s);
-	}
+  def simplifyDigits(s: String): String = {
+    if(s == null || s.length() == 0) {
+	    s
+	  }
+    else if(isYear(s)) {
+      "<YEAR>"
+	  }
+    else if(isNumber(s)) {
+	    "<NUM>"
+	  }
+    else {
+      replaceDigits2(s)
+    }
+  }
 
   
 	//looking for 4 digit year beginning with 19 or 20
-	def isYear(s: String): Boolean = {
-      //is string 4 characters?
-	    if(s.length() == 4) {
-            //does it begin with 19 or 20?
-            if((s.charAt(0) == '1' && s.charAt(1) == '9') ||
-               (s.charAt(0) == '2' && s.charAt(1) == '0')){
-                //are the last two characters digits?
-                if(Character.isDigit(s.charAt(2)) && Character.isDigit(s.charAt(3))) {
-                    return true;
-                }
-            }
+  def isYear(s: String): Boolean = {
+    //is string 4 characters?
+    if(s.length() == 4) {
+      //does it begin with 19 or 20?
+      if((s.charAt(0) == '1' && s.charAt(1) == '9') || (s.charAt(0) == '2' && s.charAt(1) == '0')) {
+        //are the last two characters digits?
+        if(Character.isDigit(s.charAt(2)) && Character.isDigit(s.charAt(3))) {
+          return true
         }
-        return false;
-	}
+      }
+    }
+    false
+  }
 
-	def isNumber(s: String): Boolean = {
-        for(i <- 0 until s.length()) {
-            if(!Character.isDigit(s.charAt(i))){
-                return false;
-            }
-        }
-        return true;
+  def isNumber(s: String): Boolean = {
+    for(i <- 0 until s.length()) {
+      if(!Character.isDigit(s.charAt(i))){
+        return false
+      }
+    }
+    true
 	}
 	
-	def replaceDigits2(s: String): String = {
-	    val c1: Array[Char] = s.toCharArray()
-	    val c2: Array[Char] = new Array[Char](c1.length)
-      for(i <- 0 until s.length()) {
-          if(Character.isDigit(c1(i))) {
-	            c2(i) = '#'
-	        } else {
-	            c2(i) = c1(i)
-	        }
-	    }
-	    new String(c2)
-	 }
+  def replaceDigits2(s: String): String = {
+    val c1: Array[Char] = s.toCharArray()
+    val c2: Array[Char] = new Array[Char](c1.length)
+    for(i <- 0 until s.length()) {
+      if(Character.isDigit(c1(i))) {
+        c2(i) = '#'
+      } else {
+        c2(i) = c1(i)
+      }
+    }
+    new String(c2)
+  }
 
   
   /** Implements Levenshtein Distance, with specific operation costs to go from this String to String s2. */

--- a/src/main/scala/cc/factorie/app/strings/package.scala
+++ b/src/main/scala/cc/factorie/app/strings/package.scala
@@ -69,13 +69,7 @@ package object strings {
   val recentYearRegex = "(19|20)\\d\\d".r
   val digitsRegex = "\\d+".r
   val containsDigitRegex = ".*\\d.*".r
-  /** Return input string, with digits replaced, either the whole string with "<YEAR>" or "<NUM>" or just the digits replaced with "#" */
-  def simplifyDigits(word:String): String = {
-    if (recentYearRegex.findFirstIn(word).nonEmpty) "<YEAR>"
-    else if (digitsRegex.findFirstIn(word).nonEmpty) "<NUM>"
-    else if (containsDigitRegex.findFirstIn(word).nonEmpty) word.replaceAll("\\d","#")
-    else word
-  }
+
   def collapseDigits(word:String): String = {
     if (cc.factorie.app.nlp.lexicon.NumberWords.containsWord(word) || containsDigitRegex.findFirstIn(word).nonEmpty) "0" else word
   }
@@ -83,6 +77,63 @@ package object strings {
     if (cc.factorie.app.nlp.lexicon.NumberWords.containsWord(word)) "<NUM>" else digitsRegex.replaceAllIn(word, "0")
   }
 
+  
+    def simplifyDigits(s: String): String = {
+	    if(s == null || s.length() == 0) {
+	        return s
+	    }
+	    
+	    if(isYear(s)) {
+	        return "<YEAR>";
+	    }
+        
+	    if(isNumber(s)) {
+	        return "<NUM>";
+	    }
+	    
+	    replaceDigits2(s);
+	}
+
+  
+	//looking for 4 digit year beginning with 19 or 20
+	def isYear(s: String): Boolean = {
+      //is string 4 characters?
+	    if(s.length() == 4) {
+            //does it begin with 19 or 20?
+            if((s.charAt(0) == '1' && s.charAt(1) == '9') ||
+               (s.charAt(0) == '2' && s.charAt(1) == '0')){
+                //are the last two characters digits?
+                if(Character.isDigit(s.charAt(2)) && Character.isDigit(s.charAt(3))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+	}
+
+	def isNumber(s: String): Boolean = {
+        for(i <- 0 until s.length()) {
+            if(!Character.isDigit(s.charAt(i))){
+                return false;
+            }
+        }
+        return true;
+	}
+	
+	def replaceDigits2(s: String): String = {
+	    val c1: Array[Char] = s.toCharArray()
+	    val c2: Array[Char] = new Array[Char](c1.length)
+      for(i <- 0 until s.length()) {
+          if(Character.isDigit(c1(i))) {
+	            c2(i) = '#'
+	        } else {
+	            c2(i) = c1(i)
+	        }
+	    }
+	    new String(c2)
+	 }
+
+  
   /** Implements Levenshtein Distance, with specific operation costs to go from this String to String s2. */
   def editDistance(s:String, s2: String, substCost: Int = 1, deleteCost: Int = 1, insertCost: Int = 1): Int = {
     if (s.length == 0) s2.length

--- a/src/test/scala/cc/factorie/app/strings/PackageTest.scala
+++ b/src/test/scala/cc/factorie/app/strings/PackageTest.scala
@@ -1,0 +1,23 @@
+package cc.factorie.app.strings
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class PackageTest {
+  
+  @Test def testSimplifyDigits(): Unit = {
+		assertEquals("<YEAR>", simplifyDigits("2016"));
+		assertEquals("<YEAR>", simplifyDigits("1984"));
+		assertEquals("##a#", simplifyDigits("19a4"));
+		assertEquals("###s", simplifyDigits("201s"));
+	  assertEquals("<NUM>", simplifyDigits("20161234"));
+	  assertEquals("<NUM>", simplifyDigits("010101"));
+	  assertEquals("<NUM>", simplifyDigits("0"));
+	  assertEquals("<NUM>", simplifyDigits("987654321"));
+	  assertEquals("#########a", simplifyDigits("987654321a"));
+	  assertEquals("####a", simplifyDigits("1984a"));
+	  assertEquals("#a", simplifyDigits("0a"));
+	  assertEquals("a#", simplifyDigits("a0"));
+	  assertEquals("A-# St#ak Sauc#", simplifyDigits("A-1 St3ak Sauc3"));
+  }
+}

--- a/src/test/scala/cc/factorie/app/strings/PackageTest.scala
+++ b/src/test/scala/cc/factorie/app/strings/PackageTest.scala
@@ -6,18 +6,18 @@ import org.junit.Assert.assertEquals
 class PackageTest {
   
   @Test def testSimplifyDigits(): Unit = {
-		assertEquals("<YEAR>", simplifyDigits("2016"))
-		assertEquals("<YEAR>", simplifyDigits("1984"))
-		assertEquals("##a#", simplifyDigits("19a4"))
-		assertEquals("###s", simplifyDigits("201s"))
-	  assertEquals("<NUM>", simplifyDigits("20161234"))
-	  assertEquals("<NUM>", simplifyDigits("010101"))
-	  assertEquals("<NUM>", simplifyDigits("0"))
-	  assertEquals("<NUM>", simplifyDigits("987654321"))
-	  assertEquals("#########a", simplifyDigits("987654321a"))
-	  assertEquals("####a", simplifyDigits("1984a"))
-	  assertEquals("#a", simplifyDigits("0a"))
-	  assertEquals("a#", simplifyDigits("a0"))
-	  assertEquals("A-# St#ak Sauc#", simplifyDigits("A-1 St3ak Sauc3"))
+    assertEquals("<YEAR>", simplifyDigits("2016"))
+    assertEquals("<YEAR>", simplifyDigits("1984"))
+    assertEquals("##a#", simplifyDigits("19a4"))
+    assertEquals("###s", simplifyDigits("201s"))
+    assertEquals("<NUM>", simplifyDigits("20161234"))
+    assertEquals("<NUM>", simplifyDigits("010101"))
+    assertEquals("<NUM>", simplifyDigits("0"))
+    assertEquals("<NUM>", simplifyDigits("987654321"))
+    assertEquals("#########a", simplifyDigits("987654321a"))
+    assertEquals("####a", simplifyDigits("1984a"))
+    assertEquals("#a", simplifyDigits("0a"))
+    assertEquals("a#", simplifyDigits("a0"))
+    assertEquals("A-# St#ak Sauc#", simplifyDigits("A-1 St3ak Sauc3"))
   }
 }

--- a/src/test/scala/cc/factorie/app/strings/PackageTest.scala
+++ b/src/test/scala/cc/factorie/app/strings/PackageTest.scala
@@ -6,18 +6,18 @@ import org.junit.Assert.assertEquals
 class PackageTest {
   
   @Test def testSimplifyDigits(): Unit = {
-		assertEquals("<YEAR>", simplifyDigits("2016"));
-		assertEquals("<YEAR>", simplifyDigits("1984"));
-		assertEquals("##a#", simplifyDigits("19a4"));
-		assertEquals("###s", simplifyDigits("201s"));
-	  assertEquals("<NUM>", simplifyDigits("20161234"));
-	  assertEquals("<NUM>", simplifyDigits("010101"));
-	  assertEquals("<NUM>", simplifyDigits("0"));
-	  assertEquals("<NUM>", simplifyDigits("987654321"));
-	  assertEquals("#########a", simplifyDigits("987654321a"));
-	  assertEquals("####a", simplifyDigits("1984a"));
-	  assertEquals("#a", simplifyDigits("0a"));
-	  assertEquals("a#", simplifyDigits("a0"));
-	  assertEquals("A-# St#ak Sauc#", simplifyDigits("A-1 St3ak Sauc3"));
+		assertEquals("<YEAR>", simplifyDigits("2016"))
+		assertEquals("<YEAR>", simplifyDigits("1984"))
+		assertEquals("##a#", simplifyDigits("19a4"))
+		assertEquals("###s", simplifyDigits("201s"))
+	  assertEquals("<NUM>", simplifyDigits("20161234"))
+	  assertEquals("<NUM>", simplifyDigits("010101"))
+	  assertEquals("<NUM>", simplifyDigits("0"))
+	  assertEquals("<NUM>", simplifyDigits("987654321"))
+	  assertEquals("#########a", simplifyDigits("987654321a"))
+	  assertEquals("####a", simplifyDigits("1984a"))
+	  assertEquals("#a", simplifyDigits("0a"))
+	  assertEquals("a#", simplifyDigits("a0"))
+	  assertEquals("A-# St#ak Sauc#", simplifyDigits("A-1 St3ak Sauc3"))
   }
 }


### PR DESCRIPTION
I found another performance bottle neck in FACTORIE in the cc.factorie.app.strings.simplifyDigits method.  In one configuration, the profiler was showing that 12% of the CPU sampling was taking place in that method executing "findFirstIn".  So, I re-implemented the method using a more direct approach with string/character examination.  Also, I believe the logic of the original implementation is incorrect.  The value returned by simplfiyDigits("A1") is "<NUM>" but I would expect it to be "A#".  I don't think it is possible for the third condition to be invoked based on the way the second one works.  This pull request adds a faster implementation of simplifyDigits and unit tests that capture what I think the exptected behavior should be.  The unit tests do not pass with the regex version of the method.  I didn't see any change in accuracy of the NER model I built with this change.  

After making this fix, a process that once took 205 seconds now takes about 195 seconds and the time spent doing findFirstIn went from 12.4% to 5.2%.  I didn't track down where else the findFirstIn method was being called from.  
