### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To accomplish the same with sbt, type
 $ ./sbt -J-Xmx2G with-nlp-resources:assembly
 
 ```
-##Try out a simple example
+## Try out a simple example
 
 To get an idea what a simple FACTORIE program might look like, open one of the class files in the tutorial package
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
