### PR TITLE
patch for object ConllChainNer creation failure #385

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.majorVersion>2.11</scala.majorVersion>
-    <scala.minorVersion>.8</scala.minorVersion>
+    <scala.minorVersion>.11</scala.minorVersion>
     <scalatest.version>2.2.5</scalatest.version>
     <junit.version>4.10</junit.version>
   </properties>

--- a/src/main/scala/cc/factorie/app/nlp/ner/ChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/ChainNer.scala
@@ -64,7 +64,7 @@ class ConllChainNer(implicit mp:ModelProvider[ConllChainNer], nerLexiconFeatures
 }
 
 //TODO this serialized model doesn't exist yet?
-object ConllChainNer extends ConllChainNer()(ModelProvider.classpath(), StaticLexiconFeatures()) with Serializable
+object ConllChainNer extends ConllChainNer()(ModelProvider.classpath[ConllChainNer](), StaticLexiconFeatures()) with Serializable
 
 class OntonotesChainNer()(implicit mp:ModelProvider[OntonotesChainNer], nerLexiconFeatures:NerLexiconFeatures)
   extends ChainNer[BilouOntonotesNerTag](BilouOntonotesNerDomain, (t, s) => new BilouOntonotesNerTag(t, s), l => l.token, mp.provide, nerLexiconFeatures) {
@@ -73,7 +73,7 @@ class OntonotesChainNer()(implicit mp:ModelProvider[OntonotesChainNer], nerLexic
   def newSpan(sec: Section, start: Int, length: Int, category: String) = new OntonotesNerSpan(sec, start, length, category)
 }
 
-object OntonotesChainNer extends OntonotesChainNer()(ModelProvider.classpath(), StaticLexiconFeatures())
+object OntonotesChainNer extends OntonotesChainNer()(ModelProvider.classpath[OntonotesChainNer](), StaticLexiconFeatures())
 
 /**
  * A base class for finite-state named entity recognizers

--- a/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
+++ b/src/main/scala/cc/factorie/app/nlp/ner/StackedChainNer.scala
@@ -617,7 +617,7 @@ class ConllStackedChainNer(embeddingMap: SkipGramEmbedding,
 
 //object ConllStackedChainNer extends ConllStackedChainNer(SkipGramEmbedding, 100, 1.0, true, ClasspathURL[ConllStackedChainNer](".factorie"))
 class NoEmbeddingsConllStackedChainNer()(implicit mp:ModelProvider[NoEmbeddingsConllStackedChainNer], nerLexiconFeatures:NerLexiconFeatures) extends ConllStackedChainNer(null, 0, 0.0, false)(mp, nerLexiconFeatures) with Serializable
-object NoEmbeddingsConllStackedChainNer extends NoEmbeddingsConllStackedChainNer()(ModelProvider.classpath(), StaticLexiconFeatures()) with Serializable
+object NoEmbeddingsConllStackedChainNer extends NoEmbeddingsConllStackedChainNer()(ModelProvider.classpath[NoEmbeddingsConllStackedChainNer](), StaticLexiconFeatures()) with Serializable
 
 class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
                                embeddingDim: Int,
@@ -634,7 +634,7 @@ class OntonotesStackedChainNer(embeddingMap: SkipGramEmbedding,
     mp.provide, nerLexiconFeatures)
 
 class NoEmbeddingsOntonotesStackedChainNer()(implicit mp:ModelProvider[NoEmbeddingsOntonotesStackedChainNer], nerLexiconFeatures: NerLexiconFeatures) extends OntonotesStackedChainNer(null, 0, 0.0, false)(mp, nerLexiconFeatures) with Serializable
-object NoEmbeddingsOntonotesStackedChainNer extends NoEmbeddingsOntonotesStackedChainNer()(ModelProvider.classpath(), StaticLexiconFeatures()) with Serializable
+object NoEmbeddingsOntonotesStackedChainNer extends NoEmbeddingsOntonotesStackedChainNer()(ModelProvider.classpath[NoEmbeddingsOntonotesStackedChainNer](), StaticLexiconFeatures()) with Serializable
 
 
 class StackedChainNerOpts extends CmdOptions with SharedNLPCmdOptions{


### PR DESCRIPTION
scala upgraded to 2.11.11
add the missing ClassTag in NER annotators